### PR TITLE
Renamed scrape metric constants

### DIFF
--- a/src/main/java/ai/asserts/aws/MetricNameUtil.java
+++ b/src/main/java/ai/asserts/aws/MetricNameUtil.java
@@ -21,12 +21,12 @@ import static java.util.stream.Collectors.joining;
 
 @Component
 public class MetricNameUtil {
-    public static final String SELF_LATENCY_METRIC = "cw_scrape_milliseconds";
-    public static final String SELF_OPERATION_LABEL = "operation";
-    public static final String SELF_REGION_LABEL = "region";
-    public static final String SELF_NAMESPACE_LABEL = "namespace";
-    public static final String SELF_INTERVAL_LABEL = "interval";
-    public static final String SELF_FUNCTION_NAME_LABEL = "function_name";
+    public static final String SCRAPE_LATENCY_METRIC = "cw_scrape_milliseconds";
+    public static final String SCRAPE_OPERATION_LABEL = "operation";
+    public static final String SCRAPE_REGION_LABEL = "region";
+    public static final String SCRAPE_NAMESPACE_LABEL = "cw_namespace";
+    public static final String SCRAPE_INTERVAL_LABEL = "interval";
+    public static final String SCRAPE_FUNCTION_NAME_LABEL = "function_name";
 
     private final Map<String, String> NAMESPACE_TO_METRIC_PREFIX = new ImmutableMap.Builder<String, String>()
             .put(CWNamespace.lambda.getNamespace(), "aws_lambda")

--- a/src/main/java/ai/asserts/aws/cloudwatch/metrics/MetricScrapeTask.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/metrics/MetricScrapeTask.java
@@ -27,10 +27,10 @@ import java.util.TimerTask;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import static ai.asserts.aws.MetricNameUtil.SELF_INTERVAL_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SELF_LATENCY_METRIC;
-import static ai.asserts.aws.MetricNameUtil.SELF_OPERATION_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SELF_REGION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_INTERVAL_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
 
 @Slf4j
 @Setter
@@ -119,11 +119,11 @@ public class MetricScrapeTask extends TimerTask {
 
     private void captureLatency(long timeTaken) {
         gaugeExporter.exportMetric(
-                SELF_LATENCY_METRIC, "scraper Instrumentation",
+                SCRAPE_LATENCY_METRIC, "scraper Instrumentation",
                 ImmutableMap.of(
-                        SELF_REGION_LABEL, region,
-                        SELF_OPERATION_LABEL, "get_metric_data",
-                        SELF_INTERVAL_LABEL, intervalSeconds + ""
+                        SCRAPE_REGION_LABEL, region,
+                        SCRAPE_OPERATION_LABEL, "get_metric_data",
+                        SCRAPE_INTERVAL_LABEL, intervalSeconds + ""
                 ), Instant.now(), timeTaken * 1.0D);
     }
 

--- a/src/main/java/ai/asserts/aws/cloudwatch/query/MetricQueryProvider.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/query/MetricQueryProvider.java
@@ -33,10 +33,10 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import static ai.asserts.aws.MetricNameUtil.SELF_LATENCY_METRIC;
-import static ai.asserts.aws.MetricNameUtil.SELF_NAMESPACE_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SELF_OPERATION_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SELF_REGION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_NAMESPACE_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
 
 @Component
 @Slf4j
@@ -135,11 +135,11 @@ public class MetricQueryProvider {
     }
 
     private void captureLatency(String region, NamespaceConfig ns, long timeTaken) {
-        gaugeExporter.exportMetric(SELF_LATENCY_METRIC, "scraper Instrumentation",
+        gaugeExporter.exportMetric(SCRAPE_LATENCY_METRIC, "scraper Instrumentation",
                 ImmutableMap.of(
-                        SELF_REGION_LABEL, region,
-                        SELF_OPERATION_LABEL, "list_metrics",
-                        SELF_NAMESPACE_LABEL, CWNamespace.valueOf(ns.getName()).getNamespace()
+                        SCRAPE_REGION_LABEL, region,
+                        SCRAPE_OPERATION_LABEL, "list_metrics",
+                        SCRAPE_NAMESPACE_LABEL, CWNamespace.valueOf(ns.getName()).getNamespace()
                 ), Instant.now(), timeTaken * 1.0D);
     }
 

--- a/src/main/java/ai/asserts/aws/lambda/LambdaFunctionScraper.java
+++ b/src/main/java/ai/asserts/aws/lambda/LambdaFunctionScraper.java
@@ -29,9 +29,9 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
-import static ai.asserts.aws.MetricNameUtil.SELF_LATENCY_METRIC;
-import static ai.asserts.aws.MetricNameUtil.SELF_OPERATION_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SELF_REGION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
 
 @Component
 @Slf4j
@@ -98,10 +98,10 @@ public class LambdaFunctionScraper {
     }
 
     private void captureLatency(String region, long timeTaken) {
-        gaugeExporter.exportMetric(SELF_LATENCY_METRIC, "scraper Instrumentation",
+        gaugeExporter.exportMetric(SCRAPE_LATENCY_METRIC, "scraper Instrumentation",
                 ImmutableMap.of(
-                        SELF_REGION_LABEL, region,
-                        SELF_OPERATION_LABEL, "scrape_lambda_functions"
+                        SCRAPE_REGION_LABEL, region,
+                        SCRAPE_OPERATION_LABEL, "scrape_lambda_functions"
                 ), Instant.now(), timeTaken * 1.0D);
     }
 }

--- a/src/main/java/ai/asserts/aws/lambda/LambdaLogMetricScrapeTask.java
+++ b/src/main/java/ai/asserts/aws/lambda/LambdaLogMetricScrapeTask.java
@@ -33,10 +33,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TimerTask;
 
-import static ai.asserts.aws.MetricNameUtil.SELF_FUNCTION_NAME_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SELF_LATENCY_METRIC;
-import static ai.asserts.aws.MetricNameUtil.SELF_OPERATION_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SELF_REGION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_FUNCTION_NAME_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
 import static java.lang.String.format;
 
 @Slf4j
@@ -143,11 +143,11 @@ public class LambdaLogMetricScrapeTask extends TimerTask {
     }
 
     private void captureLatency(LambdaFunction functionConfig, long timeTaken) {
-        gaugeExporter.exportMetric(SELF_LATENCY_METRIC, "scraper Instrumentation",
+        gaugeExporter.exportMetric(SCRAPE_LATENCY_METRIC, "scraper Instrumentation",
                 ImmutableMap.of(
-                        SELF_REGION_LABEL, region,
-                        SELF_OPERATION_LABEL, "scrape_lambda_logs",
-                        SELF_FUNCTION_NAME_LABEL, functionConfig.getName()
+                        SCRAPE_REGION_LABEL, region,
+                        SCRAPE_OPERATION_LABEL, "scrape_lambda_logs",
+                        SCRAPE_FUNCTION_NAME_LABEL, functionConfig.getName()
                 ), Instant.now(), timeTaken * 1.0D);
     }
 

--- a/src/main/java/ai/asserts/aws/resource/TagFilterResourceProvider.java
+++ b/src/main/java/ai/asserts/aws/resource/TagFilterResourceProvider.java
@@ -31,10 +31,10 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static ai.asserts.aws.MetricNameUtil.SELF_LATENCY_METRIC;
-import static ai.asserts.aws.MetricNameUtil.SELF_NAMESPACE_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SELF_OPERATION_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SELF_REGION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_NAMESPACE_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
 import static java.lang.String.format;
 
 @Component
@@ -112,11 +112,11 @@ public class TagFilterResourceProvider {
     }
 
     private void captureLatency(String region, CWNamespace cwNamespace, long timeTaken) {
-        gaugeExporter.exportMetric(SELF_LATENCY_METRIC, "scraper Instrumentation",
+        gaugeExporter.exportMetric(SCRAPE_LATENCY_METRIC, "scraper Instrumentation",
                 ImmutableMap.of(
-                        SELF_REGION_LABEL, region,
-                        SELF_OPERATION_LABEL, "get_resources_with_tags",
-                        SELF_NAMESPACE_LABEL, cwNamespace.getNamespace()
+                        SCRAPE_REGION_LABEL, region,
+                        SCRAPE_OPERATION_LABEL, "get_resources_with_tags",
+                        SCRAPE_NAMESPACE_LABEL, cwNamespace.getNamespace()
                 ), Instant.now(), timeTaken * 1.0D);
     }
 


### PR DESCRIPTION
[sc8722]

Renamed scrape metric constants
Changed label name from `namespace` to `cw_namespace`
