### PR TITLE
aws-exporter version is missing the git hash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Stage 1 - Build
 FROM gradle:jdk8 as builder
 RUN gradle --version && java -version
+RUN apt-get install git && git --version
+
 WORKDIR /home/gradle/app
 # Only copy gradle dependency-related files
 COPY --chown=gradle:gradle build.gradle /home/gradle/app/
@@ -16,6 +18,7 @@ COPY --chown=gradle:gradle gradle.properties /home/gradle/app/
 RUN gradle build --no-daemon > /dev/null 2>&1 || true
 
 COPY --chown=gradle:gradle ./src /home/gradle/app/src
+COPY --chown=gradle:gradle ./.git /home/gradle/app/.git
 RUN gradle bootJar --no-daemon
 
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/asserts/story/9076

Problem is that when you build locally via gradle or intelliaJ
the gradle task to set the version runs a git rev-parse cmd.
`version = new Date().format("YY.M.0") + '.' + 'git rev-parse --short HEAD'.execute().text.trim()`

git resolves for you locally but in CICD pipeline, the App is getting built inside a docker container that doesn't have git installed.

I've modified the Dockerfile to install git and copy in the repos .git store at so it's available before the `bootJar` gradle task is executed.

Tested by:
1. Building new container with changes on docker locally
```
docker build -t 543343501704.dkr.ecr.us-west-2.amazonaws.com/ai.asserts.aws-exporter:1.0.0 .
```
2. Running container on docker locally
```sh
docker run -d -p 8010:8010 --rm 543343501704.dkr.ecr.us-west-2.amazonaws.com/ai.asserts.aws-exporter:1.0.0
```
3.  Opening its `/aws-exporter/actuator/prometheus` endpoint in a local browser
```
open http://localhost:8010/aws-exporter/actuator/prometheus
```
4. Visually inspecting the new`springboot_build_info` metric being published (this will become the `asserts:version:info
` synthetic metic)
```
# HELP springboot_build_info Spring boot build info
# TYPE springboot_build_info gauge
springboot_build_info{artifact="app",group="ai.asserts",name="app",time="2021-10-22T22:39:31.089Z",version="21.10.0.ec5e31c",} 1.0
```