### PR TITLE
Bake VMAgent into AWS-Exporter image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # Stage 1 - Build
+ARG VM_VERSION=v1.69.0
+FROM victoriametrics/vmagent:$VM_VERSION as vmagent
 FROM gradle:jdk8 as builder
 RUN gradle --version && java -version
 RUN apt-get install git && git --version
@@ -31,6 +33,7 @@ COPY --from=builder /home/gradle/app/src/dist/conf/cloudwatch_scrape_config_samp
 COPY --from=builder /home/gradle/app/build/libs/* ./
 COPY --from=builder /home/gradle/app/build/resources/main/*.xml ./
 COPY --from=builder /home/gradle/app/build/resources/main/*.properties ./
+COPY --from=vmagent /vmagent-prod /bin/vmagent
 # COPY jmx_prometheus_javaagent-0.16.1.jar ./
 # COPY httpserver_config.yml ./
 CMD ["/bin/sh", "-c", "java -jar app-*.jar --spring.config.location=application.properties"]


### PR DESCRIPTION
Story details: https://app.shortcut.com/asserts/story/10038

@jradhakrishnan this is the basic change need to bake vmagent into same image alongside `aws-cw-exporter`
I added it to container's `/bin` folder so it's easily usable like any other CLI util.

A couple open questions.
How should we invoke VMAgent?
From exporter Java code or container init script?

To verify it's working/available run:
```sh
# build image locally
docker build -t ai.asserts.aws-exporter:latest .

# run image and override default CMD to launch exporter jar with CMD for vmagent help 
docker run ai.asserts.aws-exporter:latest "/bin/vmagent" -h
```

VMAgent can be launched with a flag that enables it to be configured via environment variables.
```yaml
-envflag.enable
  Whether to enable reading flags from environment variables additionally to command line. 
  Command line flag values have priority over values from environment vars. 
  Flags are read only from command line if this flag isn't set.
```
[More Info](https://docs.victoriametrics.com/#environment-variables) about environment vars with VM services.