### PR TITLE
Migrate AWS Cloudwatch Exporter use dockerhub instead of ECR

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,11 +1,10 @@
 apiVersion: v2
-name: aws-exporter
-description: Runs aws-exporter
 type: application
-
+name: aws-exporter
+description: Helm Char for Asserts Aws-Exporter
 version: 0.1.0
 appVersion: 0.1.0
-
+icon: https://www.asserts.ai/favicon.png
 maintainers:
   - name: Asserts
     url: https://github.com/asserts

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "aws-exporter.labels" -}}
+helm.sh/chart: {{ include "aws-exporter.chart" . }}
+{{ include "aws-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "aws-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aws-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aws-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "aws-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: aws-exporter
+  name: {{ include "aws-exporter.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: aws-exporter
+    {{- include "aws-exporter.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
@@ -15,6 +15,11 @@ spec:
       labels:
         app: aws-exporter
     spec:
+      {{- with .Values.serviceAccount.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "aws-exporter.serviceAccountName" . }}
       containers:
       - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         name: {{ .Chart.Name }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: aws-exporter
+  name: {{ include "aws-exporter.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: aws-exporter
+    {{- include "aws-exporter.labels" . | nindent 4 }}
 spec:
+type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.aws.port }}
       targetPort: {{ .Values.service.aws.port }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aws-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "aws-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -22,3 +22,6 @@ serviceMonitor:
     - port: aws
       path: /aws-exporter/actuator/prometheus
     # - port: jmx
+
+serviceAccount:
+  create: false

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,7 @@
 # Default values for AWS Exporter
 
 image:
-  repository: 543343501704.dkr.ecr.us-west-2.amazonaws.com/ai.asserts.aws-cloudwatch-exporter
+  repository: asserts/aws-cloudwatch-exporter
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: 0.1.0


### PR DESCRIPTION
Story details: https://app.shortcut.com/asserts/story/10672

Already created new image repo in DockerHub
Here Im updating the image repo the chart pulls from and and 
adding a Service Account so AWS Cloudwatch Exporter can pull from DockerHub