### PR TITLE
Add support for events and alarms from cloud trail

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,8 @@ dependencies {
             "software.amazon.awssdk:config:$awsSdkVersion",
             "io.opentelemetry:opentelemetry-proto:$opentelemetryProtoBufVersion",
             "com.google.protobuf:protobuf-java:$protobufVersion",
-            "com.google.protobuf:protobuf-java-util:$protobufVersion"
+            "com.google.protobuf:protobuf-java-util:$protobufVersion",
+            "software.amazon.awssdk:cloudtrail:$awsSdkVersion",
     )
 
     compileOnly(

--- a/src/dist/conf/cloudwatch_scrape_config_sample.yml
+++ b/src/dist/conf/cloudwatch_scrape_config_sample.yml
@@ -1,6 +1,7 @@
 delay: 60
 scrapeInterval: 300
 discoverECSTasks: true
+importEvents: true
 regions:
   - us-west-2
 namespaces:

--- a/src/main/java/ai/asserts/aws/AWSClientProvider.java
+++ b/src/main/java/ai/asserts/aws/AWSClientProvider.java
@@ -4,6 +4,7 @@ package ai.asserts.aws;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudtrail.CloudTrailClient;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
 import software.amazon.awssdk.services.config.ConfigClient;
@@ -37,5 +38,9 @@ public class AWSClientProvider {
 
     public ConfigClient getConfigClient(String region) {
         return ConfigClient.builder().region(Region.of(region)).build();
+    }
+
+    public CloudTrailClient getCloudTrailClient(String region) {
+        return CloudTrailClient.builder().region(Region.of(region)).build();
     }
 }

--- a/src/main/java/ai/asserts/aws/MetricTaskManager.java
+++ b/src/main/java/ai/asserts/aws/MetricTaskManager.java
@@ -5,6 +5,7 @@ import ai.asserts.aws.cloudwatch.config.MetricConfig;
 import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
 import ai.asserts.aws.cloudwatch.config.ScrapeConfigProvider;
 import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter;
+import ai.asserts.aws.exporter.EventsExporter;
 import ai.asserts.aws.exporter.MetricScrapeTask;
 import com.google.common.annotations.VisibleForTesting;
 import io.micrometer.core.annotation.Timed;
@@ -32,6 +33,7 @@ public class MetricTaskManager implements InitializingBean {
     private final ScrapeConfigProvider scrapeConfigProvider;
     private final ECSServiceDiscoveryExporter ecsServiceDiscoveryExporter;
     private final TaskThreadPool taskThreadPool;
+    private final EventsExporter eventsExporter;
 
     /**
      * Maintains the last scrape time for all the metricso of a given scrape interval. The scrapes are
@@ -48,6 +50,7 @@ public class MetricTaskManager implements InitializingBean {
                 .flatMap(nc -> nc.getMetrics().stream().map(MetricConfig::getScrapeInterval))
                 .forEach(interval ->
                         regions.forEach(region -> addScrapeTask(scrapeConfig, interval, region)));
+        eventsExporter.register(collectorRegistry);
     }
 
     @SuppressWarnings("unused")
@@ -61,6 +64,7 @@ public class MetricTaskManager implements InitializingBean {
                 .forEach(task -> executorService.submit(task::update));
 
         executorService.submit(ecsServiceDiscoveryExporter);
+        executorService.submit(eventsExporter::update);
     }
 
     @VisibleForTesting

--- a/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfig.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfig.java
@@ -56,6 +56,9 @@ public class ScrapeConfig {
     @Builder.Default
     private Set<String> discoverResourceTypes = new TreeSet<>();
 
+    @Builder.Default
+    private boolean importEvents = false;
+
     private List<ECSTaskDefScrapeConfig> ecsTaskScrapeConfigs;
 
     public Optional<NamespaceConfig> getLambdaConfig() {

--- a/src/main/java/ai/asserts/aws/exporter/EventsExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/EventsExporter.java
@@ -1,0 +1,277 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.AWSClientProvider;
+import ai.asserts.aws.RateLimiter;
+import ai.asserts.aws.cloudwatch.TimeWindowBuilder;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfigProvider;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.prometheus.client.Collector;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.cloudtrail.CloudTrailClient;
+import software.amazon.awssdk.services.cloudtrail.model.Event;
+import software.amazon.awssdk.services.cloudtrail.model.LookupAttribute;
+import software.amazon.awssdk.services.cloudtrail.model.LookupAttributeKey;
+import software.amazon.awssdk.services.cloudtrail.model.LookupEventsRequest;
+import software.amazon.awssdk.services.cloudtrail.model.LookupEventsResponse;
+import software.amazon.awssdk.services.config.model.ResourceType;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
+
+@Component
+@Slf4j
+public class EventsExporter extends Collector implements MetricProvider {
+    private final ScrapeConfigProvider scrapeConfigProvider;
+    private final AWSClientProvider awsClientProvider;
+    private final RateLimiter rateLimiter;
+    private final MetricSampleBuilder sampleBuilder;
+    private final TimeWindowBuilder timeWindowBuilder;
+    private final String ALARMS_TYPE = "AWS::CloudWatch::Alarm";
+    private volatile List<MetricFamilySamples> metrics = new ArrayList<>();
+    private Map<String, MetricFamilySamples.Sample> alert_samples = new TreeMap<>();
+    private List<String> deletedAlarms = new LinkedList<>();
+
+    public EventsExporter(ScrapeConfigProvider scrapeConfigProvider,
+                          AWSClientProvider awsClientProvider,
+                          RateLimiter rateLimiter,
+                          MetricSampleBuilder sampleBuilder,
+                          TimeWindowBuilder timeWindowBuilder) {
+        this.scrapeConfigProvider = scrapeConfigProvider;
+        this.awsClientProvider = awsClientProvider;
+        this.rateLimiter = rateLimiter;
+        this.sampleBuilder = sampleBuilder;
+        this.timeWindowBuilder = timeWindowBuilder;
+    }
+
+    @Override
+    public void update() {
+        ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
+        Integer intervalSeconds = scrapeConfig.getScrapeInterval();
+        Integer delaySeconds = scrapeConfig.getDelay();
+        Set<String> discoverResourceTypes = scrapeConfig.getDiscoverResourceTypes();
+        discoverResourceTypes.add(ALARMS_TYPE);
+        List<MetricFamilySamples.Sample> samples = new ArrayList<>();
+        if (scrapeConfig.isImportEvents()) {
+            scrapeConfig.getRegions().forEach(region -> {
+                try (CloudTrailClient cloudTrailClient = awsClientProvider.getCloudTrailClient(region)) {
+                    discoverResourceTypes.forEach(resource -> {
+                        log.info("Importing Events for region {}-{}", region, resource);
+                        String nextToken = null;
+                        Instant[] timePeriod = timeWindowBuilder.getTimePeriod(region, intervalSeconds);
+                        do {
+                            LookupEventsRequest request = LookupEventsRequest.builder()
+                                    .startTime(timePeriod[0].minusSeconds(delaySeconds))
+                                    .endTime(timePeriod[1].minusSeconds(delaySeconds))
+                                    .maxResults(20)
+                                    .nextToken(nextToken)
+                                    .lookupAttributes(LookupAttribute.builder()
+                                            .attributeKey(LookupAttributeKey.RESOURCE_TYPE)
+                                            .attributeValue(resource)
+                                            .build())
+                                    .build();
+                            LookupEventsResponse response = rateLimiter.doWithRateLimit("CloudTrailClient/lookupEvents",
+                                    ImmutableSortedMap.of(
+                                            SCRAPE_REGION_LABEL, region,
+                                            SCRAPE_OPERATION_LABEL, "lookupEvents"
+                                    ),
+                                    () -> cloudTrailClient.lookupEvents(request));
+                            if (response.hasEvents()) {
+                                response.events().forEach(event -> {
+                                    if (resource.equals(ALARMS_TYPE)) {
+                                        if (isAlarmFiring(event)) {
+                                            createErrorAlert(event, resource, region);
+                                        } else {
+                                            stopAlarm(event);
+                                        }
+                                    } else {
+                                        samples.add(createAmendAlert(event, resource, region));
+                                    }
+                                });
+                            }
+                            nextToken = response.nextToken();
+                        } while (nextToken != null);
+                    });
+                } catch (Exception e) {
+                    log.error("Failed to extract events", e);
+                }
+            });
+            List<MetricFamilySamples> latest = new ArrayList<>();
+            if (samples.size() > 0) {
+                log.info("Adding {} Events", samples.size());
+                latest.add(sampleBuilder.buildFamily(samples));
+            }
+            if (alert_samples.size() > 0) {
+                log.info("Adding {} Alerts", alert_samples.size());
+                latest.add(sampleBuilder.buildFamily(new ArrayList<>(alert_samples.values())));
+            }
+            metrics = latest;
+            removeAlarms();
+        }
+    }
+
+    private MetricFamilySamples.Sample createAmendAlert(Event event, String resource, String region) {
+        SortedMap<String, String> labels = new TreeMap<>();
+        labels.put(SCRAPE_REGION_LABEL, region);
+        String event_name = event.eventName();
+        labels.put("alertname", event_name);
+        labels.put("alertstate", "firing");
+        labels.put("alertgroup", "aws_exporter");
+        labels.put("asserts_alert_category", "amend");
+        labels.put("asserts_severity", "info");
+        labels.put("asserts_source", event.eventSource());
+        event.resources().forEach(resource1 ->
+        {
+            if (resource.equals(resource1.resourceType())) {
+                labels.put("service", resource1.resourceName());
+                labels.put("job", resource1.resourceName());
+                labels.put("asserts_entity_type", "Service");
+                labels.put("namespace", getNamespace(resource));
+            }
+        });
+        return sampleBuilder.buildSingleSample("ALERTS", labels, 1.0);
+    }
+
+    private void createErrorAlert(Event event, String resource, String region) {
+        SortedMap<String, String> labels = new TreeMap<>();
+        labels.put(SCRAPE_REGION_LABEL, region);
+        String event_detail = event.cloudTrailEvent();
+        JsonElement element = JsonParser.parseString(event_detail);
+        String alarmName = null;
+        String namespace = null;
+        if (element.isJsonObject()) {
+            JsonObject json_obj = (JsonObject) element;
+            JsonElement requestParam = json_obj.get("requestParameters");
+            alarmName = getJsonProperty(requestParam, "alarmName");
+            namespace = getJsonProperty(requestParam, "namespace");
+
+        }
+        if (alarmName != null && namespace != null) {
+            labels.put("alertname", alarmName);
+            labels.put("alertstate", "firing");
+            labels.put("alertgroup", "aws_exporter");
+            labels.put("asserts_alert_category", "error");
+            labels.put("asserts_severity", "warning");
+            labels.put("asserts_source", event.eventSource());
+            labels.put("namespace", namespace);
+            event.resources().forEach(resource1 ->
+            {
+                if (resource.equals(resource1.resourceType())) {
+                    labels.put("service", resource1.resourceName());
+                    labels.put("job", resource1.resourceName());
+                    labels.put("asserts_entity_type", "Service");
+                }
+            });
+            MetricFamilySamples.Sample sample = sampleBuilder.buildSingleSample("ALERTS", labels, 1.0);
+            alert_samples.put(labels.get("job"), sample);
+        }
+    }
+
+    private String getJsonProperty(JsonElement requestParam, String name) {
+        if (requestParam != null) {
+            JsonObject json_requestParam = (JsonObject) requestParam;
+            JsonElement alarmName_ele = json_requestParam.get(name);
+            if (alarmName_ele != null && alarmName_ele.isJsonPrimitive()) {
+                return alarmName_ele.getAsString();
+            }
+        }
+        return null;
+    }
+
+    private boolean isAlarmFiring(Event event) {
+        return "PutMetricAlarm".equals(event.eventName());
+    }
+
+    private String getNamespace(String resource) {
+        ResourceType type = ResourceType.fromValue(resource);
+        String namespace = "";
+        switch (type) {
+            case AWS_LAMBDA_FUNCTION:
+                namespace = "AWS/Lambda";
+                break;
+            case AWS_SQS_QUEUE:
+                namespace = "AWS/SQS";
+                break;
+            case AWS_EC2_INSTANCE:
+                namespace = "AWS/EC2";
+                break;
+            case AWS_EC2_VOLUME:
+                namespace = "AWS/EBS";
+                break;
+            case AWS_EFS_FILE_SYSTEM:
+                namespace = "AWS/EFS";
+                break;
+            case AWS_EC2_NAT_GATEWAY:
+                namespace = "AWS/NATGateway";
+                break;
+            case AWS_ELASTIC_LOAD_BALANCING_V2_LOAD_BALANCER:
+                namespace = "AWS/ApplicationELB";
+                break;
+            case AWS_ELASTIC_LOAD_BALANCING_LOAD_BALANCER:
+                namespace = "AWS/ELB";
+                break;
+            case AWS_RDS_DB_INSTANCE:
+                namespace = "AWS/RDS";
+                break;
+            case AWS_S3_BUCKET:
+                namespace = "AWS/S3";
+                break;
+            case AWS_DYNAMO_DB_TABLE:
+                namespace = "AWS/DynamoDB";
+                break;
+            case AWS_API_GATEWAY_REST_API:
+            case AWS_API_GATEWAY_V2_API:
+                namespace = "AWS/ApiGateway";
+                break;
+            case AWS_SNS_TOPIC:
+                namespace = "AWS/SNS";
+                break;
+            case AWS_KINESIS_STREAM:
+            case AWS_KINESIS_STREAM_CONSUMER:
+                namespace = "AWS/Kinesis";
+                break;
+            case AWS_ECS_SERVICE:
+                namespace = "AWS/ECS";
+                break;
+        }
+        return namespace;
+    }
+
+    private void stopAlarm(Event event) {
+        if ("DeleteAlarms".equals(event.eventName())) {
+            event.resources().forEach(resource -> {
+                deletedAlarms.add(resource.resourceName());
+            });
+        }
+    }
+
+    private void removeAlarms() {
+        if (deletedAlarms.size() > 0) {
+            deletedAlarms.forEach(key -> {
+                alert_samples.remove(key);
+            });
+        }
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        return metrics;
+    }
+}

--- a/src/test/java/ai/asserts/aws/exporter/EventsExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/EventsExporterTest.java
@@ -1,0 +1,194 @@
+/*
+ *  Copyright © 2021.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.AWSClientProvider;
+import ai.asserts.aws.RateLimiter;
+import ai.asserts.aws.cloudwatch.TimeWindowBuilder;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfigProvider;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.prometheus.client.Collector;
+import org.easymock.Capture;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudtrail.CloudTrailClient;
+import software.amazon.awssdk.services.cloudtrail.model.Event;
+import software.amazon.awssdk.services.cloudtrail.model.LookupAttribute;
+import software.amazon.awssdk.services.cloudtrail.model.LookupAttributeKey;
+import software.amazon.awssdk.services.cloudtrail.model.LookupEventsRequest;
+import software.amazon.awssdk.services.cloudtrail.model.LookupEventsResponse;
+import software.amazon.awssdk.services.cloudtrail.model.Resource;
+
+import java.time.Instant;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.capture;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EventsExporterTest extends EasyMockSupport {
+    private AWSClientProvider awsClientProvider;
+    private RateLimiter rateLimiter;
+    private MetricSampleBuilder sampleBuilder;
+    private TimeWindowBuilder timeWindowBuilder;
+    private ScrapeConfigProvider scrapeConfigProvider;
+    private Collector.MetricFamilySamples.Sample sample;
+    private Collector.MetricFamilySamples metricFamilySamples;
+    private EventsExporter testClass;
+    private ScrapeConfig scrapeConfig;
+    private CloudTrailClient cloudTrailClient;
+    private Instant now;
+
+    @BeforeEach
+    public void setup() {
+        now = Instant.now();
+        awsClientProvider = mock(AWSClientProvider.class);
+        rateLimiter = mock(RateLimiter.class);
+        sampleBuilder = mock(MetricSampleBuilder.class);
+        timeWindowBuilder = mock(TimeWindowBuilder.class);
+        scrapeConfigProvider = mock(ScrapeConfigProvider.class);
+        cloudTrailClient = mock(CloudTrailClient.class);
+        sample = mock(Collector.MetricFamilySamples.Sample.class);
+        metricFamilySamples = mock(Collector.MetricFamilySamples.class);
+        testClass = new EventsExporter(scrapeConfigProvider, awsClientProvider, rateLimiter, sampleBuilder,
+                timeWindowBuilder);
+        scrapeConfig = mock(ScrapeConfig.class);
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfig.getDelay()).andReturn(0);
+        expect(scrapeConfig.getScrapeInterval()).andReturn(60);
+        expect(scrapeConfig.isImportEvents()).andReturn(true);
+        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region"));
+    }
+
+    @Test
+    public void update() {
+        SortedSet<String> resourceType = new TreeSet<>();
+        resourceType.add("AWS::S3::Bucket");
+        expect(scrapeConfig.getDiscoverResourceTypes()).andReturn(resourceType);
+        expect(awsClientProvider.getCloudTrailClient("region")).andReturn(cloudTrailClient).anyTimes();
+        Capture<RateLimiter.AWSAPICall<LookupEventsResponse>> callbackCapture = Capture.newInstance();
+        Event event1 = Event.builder().eventName("event1").eventSource("aws").resources(Resource.builder()
+                .resourceType("AWS::S3::Bucket")
+                .resourceName("bucket1")
+                .build()).build();
+        LookupEventsResponse response = LookupEventsResponse.builder()
+                .nextToken(null)
+                .events(ImmutableList.of(event1))
+                .build();
+        Instant endTime = now.minusSeconds(0);
+        Instant startTime = now.minusSeconds(60);
+        expect(timeWindowBuilder.getTimePeriod("region", 60)).andReturn(new Instant[]{
+                now.minusSeconds(60), now}).times(2);
+        LookupEventsRequest request = LookupEventsRequest.builder()
+                .startTime(startTime)
+                .endTime(endTime)
+                .maxResults(20)
+                .nextToken(null)
+                .lookupAttributes(LookupAttribute.builder()
+                        .attributeKey(LookupAttributeKey.RESOURCE_TYPE)
+                        .attributeValue("AWS::S3::Bucket")
+                        .build())
+                .build();
+        expect(cloudTrailClient.lookupEvents(request)).andReturn(response);
+        expect(rateLimiter.doWithRateLimit(eq("CloudTrailClient/lookupEvents"),
+                anyObject(SortedMap.class), capture(callbackCapture))).andReturn(response).times(2);
+        SortedMap<String, String> labels = new TreeMap<>();
+        labels.put("alertname", "event1");
+        labels.put("alertstate", "firing");
+        labels.put("alertgroup", "aws_exporter");
+        labels.put("asserts_alert_category", "amend");
+        labels.put("asserts_severity", "info");
+        labels.put("asserts_source", "aws");
+        labels.put("service", "bucket1");
+        labels.put("job", "bucket1");
+        labels.put("asserts_entity_type", "Service");
+        labels.put("namespace", "AWS/S3");
+        labels.put("region", "region");
+        expect(sampleBuilder.buildSingleSample("ALERTS", labels, 1.0D)).andReturn(sample);
+        expect(sampleBuilder.buildFamily(ImmutableList.of(sample))).andReturn(metricFamilySamples);
+        cloudTrailClient.close();
+
+        replayAll();
+        testClass.update();
+
+        assertEquals(response, callbackCapture.getValue().makeCall());
+
+        assertEquals(ImmutableList.of(metricFamilySamples), testClass.collect());
+        verifyAll();
+    }
+
+    @Test
+    public void alarm() {
+        expect(scrapeConfig.getDiscoverResourceTypes()).andReturn(new TreeSet<>());
+        expect(awsClientProvider.getCloudTrailClient("region")).andReturn(cloudTrailClient).anyTimes();
+        Capture<RateLimiter.AWSAPICall<LookupEventsResponse>> callbackCapture = Capture.newInstance();
+        Event event1 = Event.builder()
+                .eventName("PutMetricAlarm")
+                .eventSource("aws")
+                .cloudTrailEvent("{\n" +
+                        "   \"requestParameters\":{\n" +
+                        "      \"namespace\":\"AWS/S3\",\n" +
+                        "      \"alarmName\":\"alarm1\"\n" +
+                        "   }\n" +
+                        "}")
+                .resources(Resource.builder()
+                        .resourceType("AWS::CloudWatch::Alarm")
+                        .resourceName("bucket1")
+                        .build())
+                .build();
+        LookupEventsResponse response = LookupEventsResponse.builder()
+                .nextToken(null)
+                .events(ImmutableList.of(event1))
+                .build();
+        Instant endTime = now.minusSeconds(0);
+        Instant startTime = now.minusSeconds(60);
+        expect(timeWindowBuilder.getTimePeriod("region", 60)).andReturn(new Instant[]{
+                now.minusSeconds(60), now});
+        LookupEventsRequest request = LookupEventsRequest.builder()
+                .startTime(startTime)
+                .endTime(endTime)
+                .maxResults(20)
+                .nextToken(null)
+                .lookupAttributes(LookupAttribute.builder()
+                        .attributeKey(LookupAttributeKey.RESOURCE_TYPE)
+                        .attributeValue("AWS::CloudWatch::Alarm")
+                        .build())
+                .build();
+        expect(cloudTrailClient.lookupEvents(request)).andReturn(response);
+        expect(rateLimiter.doWithRateLimit(eq("CloudTrailClient/lookupEvents"),
+                anyObject(SortedMap.class), capture(callbackCapture))).andReturn(response);
+        SortedMap<String, String> labels = new TreeMap<>();
+        labels.put("alertname", "alarm1");
+        labels.put("alertstate", "firing");
+        labels.put("alertgroup", "aws_exporter");
+        labels.put("asserts_alert_category", "error");
+        labels.put("asserts_severity", "warning");
+        labels.put("asserts_source", "aws");
+        labels.put("service", "bucket1");
+        labels.put("job", "bucket1");
+        labels.put("asserts_entity_type", "Service");
+        labels.put("namespace", "AWS/S3");
+        labels.put("region", "region");
+        expect(sampleBuilder.buildSingleSample("ALERTS", labels, 1.0D)).andReturn(sample);
+        expect(sampleBuilder.buildFamily(ImmutableList.of(sample))).andReturn(metricFamilySamples);
+        cloudTrailClient.close();
+
+        replayAll();
+        testClass.update();
+
+        assertEquals(response, callbackCapture.getValue().makeCall());
+
+        assertEquals(ImmutableList.of(metricFamilySamples), testClass.collect());
+        verifyAll();
+    }
+}


### PR DESCRIPTION
Events for configured resources will be read from  cloud trail in an interval and converted to amend alerts .
Alarms need different approach will address it separately.
[ch10882]