### PR TITLE
Configs from env

### DIFF
--- a/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfig.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfig.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.util.CollectionUtils;
 import software.amazon.awssdk.services.ecs.model.ContainerDefinition;
 import software.amazon.awssdk.services.ecs.model.TaskDefinition;
@@ -23,6 +24,7 @@ import static ai.asserts.aws.cloudwatch.model.CWNamespace.lambda;
 @Builder
 @SuppressWarnings("FieldMayBeFinal")
 public class ScrapeConfig {
+    @Setter
     private Set<String> regions;
     private List<NamespaceConfig> namespaces;
 
@@ -51,6 +53,7 @@ public class ScrapeConfig {
     private Integer logScrapeDelaySeconds = 15;
 
     @Builder.Default
+    @Setter
     private boolean discoverECSTasks = false;
 
     @Builder.Default
@@ -76,5 +79,13 @@ public class ScrapeConfig {
                         .map(ContainerDefinition::name)
                         .anyMatch(name -> name.equals(config.getContainerDefinitionName())))
                 .findFirst();
+    }
+
+    public Set<String> getRegions() {
+        return regions;
+    }
+
+    public boolean isDiscoverECSTasks() {
+        return discoverECSTasks;
     }
 }

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryController.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryController.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.ObjectMapperFactory;
+import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+@RestController
+@AllArgsConstructor
+@Slf4j
+public class ECSServiceDiscoveryController {
+    private final ECSServiceDiscoveryExporter ecsServiceDiscoveryExporter;
+    private final ObjectMapperFactory objectMapperFactory;
+
+    @RequestMapping(
+            path = "/ecs-sd-config",
+            produces = {APPLICATION_JSON_VALUE},
+            method = GET)
+    public ResponseEntity<String> getECSSDConfig() {
+        ObjectMapper objectMapper = objectMapperFactory.getObjectMapper();
+        List<StaticConfig> targets = ecsServiceDiscoveryExporter.getTargets();
+        try {
+            return ResponseEntity.ok(objectMapper.writeValueAsString(targets));
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialise ECS Targets", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -61,6 +61,9 @@ public class ECSServiceDiscoveryExporter implements Runnable {
     private final LBToECSRoutingBuilder lbToECSRoutingBuilder;
 
     @Getter
+    private volatile List<StaticConfig> targets = new ArrayList<>();
+
+    @Getter
     private volatile Set<ResourceRelation> routing = new HashSet<>();
 
     public ECSServiceDiscoveryExporter(ScrapeConfigProvider scrapeConfigProvider, AWSClientProvider awsClientProvider,
@@ -113,12 +116,13 @@ public class ECSServiceDiscoveryExporter implements Runnable {
             }
         }
         routing = newRouting;
+        targets = latestTargets;
 
         if (scrapeConfig.isDiscoverECSTasks()) {
             try {
                 File resultFile = new File(scrapeConfig.getEcsTargetSDFile());
                 objectMapperFactory.getObjectMapper().writerWithDefaultPrettyPrinter()
-                        .writeValue(resultFile, latestTargets);
+                        .writeValue(resultFile, targets);
                 log.info("Wrote ECS scrape target SD file {}", resultFile.toURI());
             } catch (IOException e) {
                 log.error("Failed to write ECS SD file", e);

--- a/src/test/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricExporterTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricExporterTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 import static org.easymock.EasyMock.expect;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -53,7 +53,6 @@ public class AlarmMetricExporterTest extends EasyMockSupport {
     @Test
     public void collect() {
         long timestamp = Instant.parse("2022-02-07T09:56:46Z").getEpochSecond();
-        Instant regionInstant = now.minusSeconds(60);
         expect(sampleBuilder.buildSingleSample("aws_cloudwatch_alarm",
                 ImmutableMap.of("metric_name", "m1", "alertname", "a1", "namespace", "n1",
                         "region", "us-west-2"), (double) timestamp)).andReturn(sample);
@@ -70,14 +69,13 @@ public class AlarmMetricExporterTest extends EasyMockSupport {
     }
 
     private void addLabels(String state) {
-        Map<String, String> labels = new HashMap<>() {{
-            put("state", state);
-            put("namespace", "n1");
-            put("metric_name", "m1");
-            put("alertname", "a1");
-            put("timestamp", "2022-02-07T09:56:46Z");
-            put("region", "us-west-2");
-        }};
+        Map<String, String> labels = new TreeMap<>(new ImmutableMap.Builder<String, String>()
+                .put("state", state)
+                .put("namespace", "n1")
+                .put("metric_name", "m1")
+                .put("alertname", "a1")
+                .put("timestamp", "2022-02-07T09:56:46Z")
+                .put("region", "us-west-2").build());
         testClass.processMetric(ImmutableList.of(labels));
     }
 }

--- a/src/test/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProviderTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProviderTest.java
@@ -10,8 +10,12 @@ import org.easymock.EasyMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ScrapeConfigProviderTest extends EasyMockSupport {
     private ScrapeConfigProvider testClass;
@@ -112,5 +116,22 @@ public class ScrapeConfigProviderTest extends EasyMockSupport {
                 new ObjectMapperFactory(),
                 "src/test/resources/cloudwatch_scrape_config.yml");
         assertNotNull(testClass.getScrapeConfig());
+        assertEquals(ImmutableSet.of("us-west-2"), testClass.getScrapeConfig().getRegions());
+        assertTrue(testClass.getScrapeConfig().isDiscoverECSTasks());
+    }
+
+    @Test
+    void envOverrides() {
+        ScrapeConfigProvider testClass = new ScrapeConfigProvider(
+                new ObjectMapperFactory(),
+                "src/test/resources/cloudwatch_scrape_config.yml") {
+            @Override
+            Map<String, String> getGetenv() {
+                return ImmutableMap.of("REGIONS", "us-east-1,us-east-2", "ENABLE_ECS_SD", "false");
+            }
+        };
+        assertNotNull(testClass.getScrapeConfig());
+        assertFalse(testClass.getScrapeConfig().isDiscoverECSTasks());
+        assertEquals(ImmutableSet.of("us-east-1", "us-east-2"), testClass.getScrapeConfig().getRegions());
     }
 }

--- a/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryControllerTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryControllerTest.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.ObjectMapperFactory;
+import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ECSServiceDiscoveryControllerTest extends EasyMockSupport {
+
+    @Test
+    public void getECSSDConfig() throws Exception {
+        ECSServiceDiscoveryExporter mockExporter = mock(ECSServiceDiscoveryExporter.class);
+        ObjectMapperFactory oMF = mock(ObjectMapperFactory.class);
+        ObjectMapper mockMapper = mock(ObjectMapper.class);
+        StaticConfig mockConfig = mock(StaticConfig.class);
+
+        expect(mockExporter.getTargets()).andReturn(ImmutableList.of(mockConfig));
+        expect(oMF.getObjectMapper()).andReturn(mockMapper);
+        expect(mockMapper.writeValueAsString(ImmutableList.of(mockConfig))).andReturn("yaml-string");
+
+        replayAll();
+        ECSServiceDiscoveryController testClass = new ECSServiceDiscoveryController(mockExporter, oMF);
+
+        assertEquals(ResponseEntity.ok("yaml-string"), testClass.getECSSDConfig());
+
+        verifyAll();
+    }
+}

--- a/src/test/resources/cloudwatch_scrape_config.yml
+++ b/src/test/resources/cloudwatch_scrape_config.yml
@@ -1,5 +1,6 @@
 delay: 60
 scrapeInterval: 300
+discoverECSTasks: true
 regions:
   - us-west-2
 namespaces:


### PR DESCRIPTION
[ch10962]

The following can be specified through environment variables
- The regions to scrape through `REGIONS`
- Whether to do ECS Service Discovery through `ENABLE_ECS_SD` with values `[true | y | yes]`
- ECS Service Discovery is also available through an API '/aws-exporter/ecs-sd-config`

![image](https://user-images.githubusercontent.com/18289983/153243169-05f6f197-00fb-417f-b09c-835e16adcb21.png)
