### PR TITLE
add metric_namespace label for alarms

### DIFF
--- a/src/main/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricConverter.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricConverter.java
@@ -114,6 +114,7 @@ public class AlarmMetricConverter {
 
             if (alarmMetric.getNamespace() != null) {
                 labels.put("namespace", alarmMetric.getNamespace());
+                labels.put("metric_namespace", alarmMetric.getNamespace());
             }
 
             if (alarmMetric.getName() != null) {


### PR DESCRIPTION
Adding metric_namespace label to be used in cloud watch query to show graph in WB.
In some cases we tweak the original namespace for entity co-relation. We need origin namespace to get metric data from cloud watch.
[ch11268]