### PR TITLE
add metric_namespace label when state change

### DIFF
--- a/src/main/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricConverter.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricConverter.java
@@ -114,6 +114,7 @@ public class AlarmMetricConverter {
 
             if (alarmMetric.getNamespace() != null) {
                 labels.put("namespace", alarmMetric.getNamespace());
+                labels.put("metric_namespace", alarmMetric.getNamespace());
             }
 
             if (alarmMetric.getName() != null) {


### PR DESCRIPTION
Adding metric_namespace label to keep origin namespace when alarm state change notification is pushed to aws_exporter.