### PR TITLE
support assumeRole in aws-exporter

### DIFF
--- a/src/dist/conf/cloudwatch_scrape_config_sample.yml
+++ b/src/dist/conf/cloudwatch_scrape_config_sample.yml
@@ -6,6 +6,7 @@ tenant:
 ecsTaskScrapeConfigs:
   - containerDefinitionName: aws-cloudwatch-exporter
     metricPath: /aws-exporter/actuator/prometheus
+#assumeRole: arn:aws:iam::342994379019:role/aws-service-role/config.amazonaws.com/AWSServiceRoleForConfig
 regions:
   - us-west-2
 namespaces:

--- a/src/main/java/ai/asserts/aws/AWSClientProvider.java
+++ b/src/main/java/ai/asserts/aws/AWSClientProvider.java
@@ -1,8 +1,8 @@
-
 package ai.asserts.aws;
 
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.apigateway.ApiGatewayClient;
 import software.amazon.awssdk.services.autoscaling.AutoScalingClient;
@@ -20,66 +20,180 @@ import software.amazon.awssdk.services.resourcegroupstaggingapi.ResourceGroupsTa
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.sts.StsClient;
 
+import java.util.Optional;
+
 @Component
 @AllArgsConstructor
 public class AWSClientProvider {
+    private final AWSSessionProvider awsSessionProvider;
+
     public S3Client getS3Client() {
         return S3Client.builder().build();
     }
 
-    public AutoScalingClient getAutoScalingClient(String region) {
-        return AutoScalingClient.builder().region(Region.of(region)).build();
+    public AutoScalingClient getAutoScalingClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                AutoScalingClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(AutoScalingClient.builder().region(Region.of(region)).build());
     }
 
-    public ApiGatewayClient getApiGatewayClient(String region) {
-        return ApiGatewayClient.builder().region(Region.of(region)).build();
+    public ApiGatewayClient getApiGatewayClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                ApiGatewayClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(ApiGatewayClient.builder().region(Region.of(region)).build());
     }
 
-    public ElasticLoadBalancingV2Client getELBV2Client(String region) {
-        return ElasticLoadBalancingV2Client.builder().region(Region.of(region)).build();
+    public ElasticLoadBalancingV2Client getELBV2Client(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                ElasticLoadBalancingV2Client.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(ElasticLoadBalancingV2Client.builder().region(Region.of(region)).build());
     }
 
-    public ElasticLoadBalancingClient getELBClient(String region) {
-        return ElasticLoadBalancingClient.builder().region(Region.of(region)).build();
+    public ElasticLoadBalancingClient getELBClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config -> ElasticLoadBalancingClient.builder()
+                                .credentialsProvider(() -> AwsSessionCredentials.create(
+                                        config.getAccessKeyId(), config.getSecretAccessKey(),
+                                        config.getSessionToken()))
+                                .region(Region.of(region)).build())
+                        .orElse(ElasticLoadBalancingClient.builder().region(Region.of(region)).build());
     }
 
-    public CloudWatchClient getCloudWatchClient(String region) {
-        return CloudWatchClient.builder().region(Region.of(region)).build();
+    public CloudWatchClient getCloudWatchClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                CloudWatchClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(CloudWatchClient.builder().region(Region.of(region)).build());
     }
 
-    public CloudWatchLogsClient getCloudWatchLogsClient(String region) {
-        return CloudWatchLogsClient.builder().region(Region.of(region)).build();
+    public CloudWatchLogsClient getCloudWatchLogsClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                CloudWatchLogsClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(CloudWatchLogsClient.builder().region(Region.of(region)).build());
     }
 
-    public LambdaClient getLambdaClient(String region) {
-        return LambdaClient.builder().region(Region.of(region)).build();
+    public LambdaClient getLambdaClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                LambdaClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(LambdaClient.builder().region(Region.of(region)).build());
     }
 
-    public ResourceGroupsTaggingApiClient getResourceTagClient(String region) {
-        return ResourceGroupsTaggingApiClient.builder().region(Region.of(region)).build();
+    public ResourceGroupsTaggingApiClient getResourceTagClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                ResourceGroupsTaggingApiClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(ResourceGroupsTaggingApiClient.builder().region(Region.of(region)).build());
     }
 
-    public EcsClient getECSClient(String region) {
-        return EcsClient.builder().region(Region.of(region)).build();
+    public EcsClient getECSClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                EcsClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(EcsClient.builder().region(Region.of(region)).build());
     }
 
-    public ConfigClient getConfigClient(String region) {
-        return ConfigClient.builder().region(Region.of(region)).build();
+    public ConfigClient getConfigClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return sessionConfig.map(config -> ConfigClient.builder()
+                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                config.getSessionToken()))
+                        .region(Region.of(region)).build())
+                .orElse(ConfigClient.builder().region(Region.of(region)).build());
     }
 
-    public StsClient getStsClient(String region) {
-        return StsClient.builder().region(Region.of(region)).build();
+    public StsClient getStsClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                StsClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(StsClient.builder().region(Region.of(region)).build());
     }
 
-    public Ec2Client getEc2Client(String region) {
-        return Ec2Client.builder().region(Region.of(region)).build();
+    public Ec2Client getEc2Client(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                Ec2Client.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(Ec2Client.builder().region(Region.of(region)).build());
     }
 
-    public KinesisAnalyticsV2Client getKAClient(String region) {
-        return KinesisAnalyticsV2Client.builder().region(Region.of(region)).build();
+    public KinesisAnalyticsV2Client getKAClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                KinesisAnalyticsV2Client.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
+                        .orElse(KinesisAnalyticsV2Client.builder().region(Region.of(region)).build());
     }
 
-    public FirehoseClient getFirehoseClient(String region) {
-        return FirehoseClient.builder().region(Region.of(region)).build();
+    public FirehoseClient getFirehoseClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region, assumeRole);
+        return
+                sessionConfig.map(config ->
+                                FirehoseClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build()
+                        )
+                        .orElse(FirehoseClient.builder().region(Region.of(region)).build());
     }
 }

--- a/src/main/java/ai/asserts/aws/AWSSessionConfig.java
+++ b/src/main/java/ai/asserts/aws/AWSSessionConfig.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright © 2022.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.Instant;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@EqualsAndHashCode
+@ToString
+public class AWSSessionConfig {
+    private String accessKeyId;
+    private String secretAccessKey;
+    private String sessionToken;
+    private Instant expiring;
+}

--- a/src/main/java/ai/asserts/aws/AWSSessionProvider.java
+++ b/src/main/java/ai/asserts/aws/AWSSessionProvider.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright © 2022.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws;
+
+import ai.asserts.aws.cloudwatch.TimeWindowBuilder;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Component
+public class AWSSessionProvider {
+    private final TimeWindowBuilder timeWindowBuilder;
+    private Instant expiring;
+    private AWSSessionConfig currentSession;
+
+    public AWSSessionProvider(TimeWindowBuilder timeWindowBuilder) {
+        this.timeWindowBuilder = timeWindowBuilder;
+        this.expiring = Instant.now();
+        currentSession = null;
+    }
+
+    public Optional<AWSSessionConfig> getSessionCredential(String region, String assumeRole) {
+        if (assumeRole != null) {
+            if (timeWindowBuilder.getZonedDateTime(region).toInstant().compareTo(expiring) < 0) {
+                return Optional.of(currentSession);
+            }
+            StsClient stsClient = StsClient.builder().region(Region.of(region))
+                    .build();
+            AssumeRoleResponse response = stsClient.assumeRole(AssumeRoleRequest.builder()
+                    .roleSessionName("session1")
+                    .roleArn(assumeRole)
+                    .build());
+            if (response.credentials() != null) {
+                this.expiring = response.credentials().expiration();
+                currentSession = AWSSessionConfig.builder()
+                        .accessKeyId(response.credentials().accessKeyId())
+                        .secretAccessKey(response.credentials().secretAccessKey())
+                        .sessionToken(response.credentials().sessionToken())
+                        .expiring(response.credentials().expiration())
+                        .build();
+                return Optional.of(currentSession);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/ai/asserts/aws/MetricTaskManager.java
+++ b/src/main/java/ai/asserts/aws/MetricTaskManager.java
@@ -70,20 +70,21 @@ public class MetricTaskManager implements InitializingBean {
     }
 
     @VisibleForTesting
-    MetricScrapeTask newScrapeTask(String region, Integer interval, Integer delay) {
-        return new MetricScrapeTask(region, interval, delay);
+    MetricScrapeTask newScrapeTask(String region, Integer interval, Integer delay, String assumeRole) {
+        return new MetricScrapeTask(region, interval, delay, assumeRole);
     }
 
     private void addScrapeTask(ScrapeConfig scrapeConfig, Integer interval, String region) {
         Map<String, MetricScrapeTask> byRegion = metricScrapeTasks.computeIfAbsent(interval,
                 k -> new TreeMap<>());
         if (!byRegion.containsKey(region)) {
-            byRegion.put(region, metricScrapeTask(region, interval, scrapeConfig.getDelay()));
+            byRegion.put(region, metricScrapeTask(region, interval, scrapeConfig.getDelay(),
+                    scrapeConfig.getAssumeRole()));
         }
     }
 
-    private MetricScrapeTask metricScrapeTask(String region, Integer interval, Integer delay) {
-        MetricScrapeTask metricScrapeTask = newScrapeTask(region, interval, delay);
+    private MetricScrapeTask metricScrapeTask(String region, Integer interval, Integer delay, String assumeRole) {
+        MetricScrapeTask metricScrapeTask = newScrapeTask(region, interval, delay, assumeRole);
         beanFactory.autowireBean(metricScrapeTask);
         metricScrapeTask.register(collectorRegistry);
         log.info("Setup metric scrape task for region {} and interval {}", region, interval);

--- a/src/main/java/ai/asserts/aws/cloudwatch/TimeWindowBuilder.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/TimeWindowBuilder.java
@@ -49,7 +49,7 @@ public class TimeWindowBuilder {
         return new Instant[]{start, end};
     }
 
-    private ZonedDateTime getZonedDateTime(String region) {
+    public ZonedDateTime getZonedDateTime(String region) {
         // S3 Storage metrics are available at just before midnight in the region's local time
         String timeZoneId = "America/Los_Angeles";
         switch (region) {

--- a/src/main/java/ai/asserts/aws/cloudwatch/alarms/AlarmFetcher.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/alarms/AlarmFetcher.java
@@ -52,7 +52,8 @@ public class AlarmFetcher {
     private List<Map<String, String>> getAlarms(String region) {
         List<Map<String, String>> labelsList = new ArrayList<>();
         String[] nextToken = new String[]{null};
-        try (CloudWatchClient cloudWatchClient = awsClientProvider.getCloudWatchClient(region)) {
+        try (CloudWatchClient cloudWatchClient = awsClientProvider.getCloudWatchClient(region,
+                scrapeConfigProvider.getScrapeConfig().getAssumeRole())) {
             do {
                 DescribeAlarmsResponse response = rateLimiter.doWithRateLimit(
                         "CloudWatchClient/describeAlarms",

--- a/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfig.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfig.java
@@ -86,6 +86,8 @@ public class ScrapeConfig {
 
     private String tenant;
 
+    private String assumeRole;
+
     @Builder.Default
     private List<DimensionToLabel> dimensionToLabels = new ArrayList<>();
 

--- a/src/main/java/ai/asserts/aws/cloudwatch/query/MetricQueryProvider.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/query/MetricQueryProvider.java
@@ -1,4 +1,3 @@
-
 package ai.asserts.aws.cloudwatch.query;
 
 import ai.asserts.aws.AWSClientProvider;
@@ -75,7 +74,8 @@ public class MetricQueryProvider {
 
         ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
         scrapeConfig.getRegions().forEach(region -> scrapeConfig.getNamespaces().forEach(ns -> {
-            try (CloudWatchClient cloudWatchClient = awsClientProvider.getCloudWatchClient(region)) {
+            try (CloudWatchClient cloudWatchClient = awsClientProvider.getCloudWatchClient(region,
+                    scrapeConfig.getAssumeRole())) {
                 Set<Resource> tagFilteredResources = resourceTagHelper.getFilteredResources(region, ns);
                 if (!ns.hasTagFilters() || tagFilteredResources.size() > 0) {
 

--- a/src/main/java/ai/asserts/aws/exporter/AccountIDProvider.java
+++ b/src/main/java/ai/asserts/aws/exporter/AccountIDProvider.java
@@ -30,7 +30,8 @@ public class AccountIDProvider implements InitializingBean {
     public void afterPropertiesSet() {
         if (!scrapeConfigProvider.getScrapeConfig().getRegions().isEmpty()) {
             String anyRegion = scrapeConfigProvider.getScrapeConfig().getRegions().iterator().next();
-            StsClient stsClient = awsClientProvider.getStsClient(anyRegion);
+            StsClient stsClient = awsClientProvider.getStsClient(anyRegion,
+                    scrapeConfigProvider.getScrapeConfig().getAssumeRole());
             accountId = stsClient.getCallerIdentity().account();
         }
     }

--- a/src/main/java/ai/asserts/aws/exporter/ApiGatewayToLambdaBuilder.java
+++ b/src/main/java/ai/asserts/aws/exporter/ApiGatewayToLambdaBuilder.java
@@ -60,7 +60,8 @@ public class ApiGatewayToLambdaBuilder {
         try {
             String accountId = accountIDProvider.getAccountId();
             scrapeConfigProvider.getScrapeConfig().getRegions().forEach(region -> {
-                try (ApiGatewayClient client = awsClientProvider.getApiGatewayClient(region)) {
+                try (ApiGatewayClient client = awsClientProvider.getApiGatewayClient(region,
+                        scrapeConfigProvider.getScrapeConfig().getAssumeRole())) {
                     SortedMap<String, String> labels = new TreeMap<>();
                     String getRestApis = "ApiGatewayClient/getRestApis";
                     labels.put(SCRAPE_OPERATION_LABEL, getRestApis);

--- a/src/main/java/ai/asserts/aws/exporter/EC2ToEBSVolumeExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/EC2ToEBSVolumeExporter.java
@@ -53,7 +53,8 @@ public class EC2ToEBSVolumeExporter {
         Set<ResourceRelation> newAttachedVolumes = new HashSet<>();
         try {
             scrapeConfigProvider.getScrapeConfig().getRegions().forEach(region -> {
-                Ec2Client ec2Client = awsClientProvider.getEc2Client(region);
+                Ec2Client ec2Client = awsClientProvider.getEc2Client(region,
+                        scrapeConfigProvider.getScrapeConfig().getAssumeRole());
                 SortedMap<String, String> telemetryLabels = new TreeMap<>();
                 String api = "Ec2Client/describeVolumes";
                 telemetryLabels.put(SCRAPE_OPERATION_LABEL, api);

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -91,7 +91,7 @@ public class ECSServiceDiscoveryExporter implements Runnable {
                 SCRAPE_NAMESPACE_LABEL, CWNamespace.ecs_svc.getNormalizedNamespace());
         for (String region : regions) {
             SortedMap<String, String> labels = new TreeMap<>(TELEMETRY_LABELS);
-            try (EcsClient ecsClient = awsClientProvider.getECSClient(region)) {
+            try (EcsClient ecsClient = awsClientProvider.getECSClient(region, scrapeConfig.getAssumeRole())) {
                 // List clusters just returns the cluster ARN. There is no need to paginate
                 ListClustersResponse listClustersResponse = rateLimiter.doWithRateLimit(
                         "EcsClient/listClusters",

--- a/src/main/java/ai/asserts/aws/exporter/KinesisAnalyticsExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/KinesisAnalyticsExporter.java
@@ -29,9 +29,9 @@ import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
 
 @Component
 public class KinesisAnalyticsExporter extends Collector implements InitializingBean {
+    public final CollectorRegistry collectorRegistry;
     private final ScrapeConfigProvider scrapeConfigProvider;
     private final AWSClientProvider awsClientProvider;
-    public final CollectorRegistry collectorRegistry;
     private final RateLimiter rateLimiter;
     private final ResourceMapper resourceMapper;
     private final MetricSampleBuilder sampleBuilder;
@@ -63,7 +63,8 @@ public class KinesisAnalyticsExporter extends Collector implements InitializingB
         List<MetricFamilySamples> newFamily = new ArrayList<>();
         List<MetricFamilySamples.Sample> samples = new ArrayList<>();
         scrapeConfigProvider.getScrapeConfig().getRegions().forEach(region -> {
-            try (KinesisAnalyticsV2Client client = awsClientProvider.getKAClient(region)) {
+            try (KinesisAnalyticsV2Client client = awsClientProvider.getKAClient(region,
+                    scrapeConfigProvider.getScrapeConfig().getAssumeRole())) {
                 String api = "KinesisAnalyticsV2Client/listApplications";
                 ListApplicationsResponse resp = rateLimiter.doWithRateLimit(
                         api, ImmutableSortedMap.of(

--- a/src/main/java/ai/asserts/aws/exporter/KinesisFirehoseExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/KinesisFirehoseExporter.java
@@ -30,9 +30,9 @@ import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
 
 @Component
 public class KinesisFirehoseExporter extends Collector implements InitializingBean {
+    public final CollectorRegistry collectorRegistry;
     private final ScrapeConfigProvider scrapeConfigProvider;
     private final AWSClientProvider awsClientProvider;
-    public final CollectorRegistry collectorRegistry;
     private final RateLimiter rateLimiter;
     private final ResourceMapper resourceMapper;
     private final MetricSampleBuilder sampleBuilder;
@@ -64,7 +64,8 @@ public class KinesisFirehoseExporter extends Collector implements InitializingBe
         List<MetricFamilySamples> newFamily = new ArrayList<>();
         List<MetricFamilySamples.Sample> samples = new ArrayList<>();
         scrapeConfigProvider.getScrapeConfig().getRegions().forEach(region -> {
-            try (FirehoseClient client = awsClientProvider.getFirehoseClient(region)) {
+            try (FirehoseClient client = awsClientProvider.getFirehoseClient(region,
+                    scrapeConfigProvider.getScrapeConfig().getAssumeRole())) {
                 String api = "FirehoseClient/listDeliveryStreams";
                 ListDeliveryStreamsResponse resp = rateLimiter.doWithRateLimit(
                         api, ImmutableSortedMap.of(

--- a/src/main/java/ai/asserts/aws/exporter/LBToASGRelationBuilder.java
+++ b/src/main/java/ai/asserts/aws/exporter/LBToASGRelationBuilder.java
@@ -56,7 +56,8 @@ public class LBToASGRelationBuilder {
                     ImmutableSortedMap.of(
                             SCRAPE_REGION_LABEL, region, SCRAPE_OPERATION_LABEL, api
                     ),
-                    () -> awsClientProvider.getAutoScalingClient(region))) {
+                    () -> awsClientProvider.getAutoScalingClient(region,
+                            scrapeConfigProvider.getScrapeConfig().getAssumeRole()))) {
                 DescribeAutoScalingGroupsResponse resp = autoScalingClient.describeAutoScalingGroups();
                 List<AutoScalingGroup> groups = resp.autoScalingGroups();
                 if (!isEmpty(groups)) {

--- a/src/main/java/ai/asserts/aws/exporter/LBToLambdaRoutingBuilder.java
+++ b/src/main/java/ai/asserts/aws/exporter/LBToLambdaRoutingBuilder.java
@@ -44,7 +44,8 @@ public class LBToLambdaRoutingBuilder {
         log.info("LB To Lambda routing relation builder about to build relations");
         Set<ResourceRelation> routing = new HashSet<>();
         scrapeConfigProvider.getScrapeConfig().getRegions().forEach(region -> {
-            try (ElasticLoadBalancingV2Client elbV2Client = awsClientProvider.getELBV2Client(region)) {
+            try (ElasticLoadBalancingV2Client elbV2Client = awsClientProvider.getELBV2Client(region,
+                    scrapeConfigProvider.getScrapeConfig().getAssumeRole())) {
                 Map<Resource, Resource> tgToLB = targetGroupLBMapProvider.getTgToLB();
                 tgToLB.keySet().forEach(tg -> {
                     try {

--- a/src/main/java/ai/asserts/aws/exporter/LambdaCapacityExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/LambdaCapacityExporter.java
@@ -90,7 +90,7 @@ public class LambdaCapacityExporter extends Collector implements MetricProvider 
 
         optional.ifPresent(lambdaConfig -> functionScraper.getFunctions().forEach((region, functions) -> {
             log.info(" - Getting Lambda account and provisioned concurrency for region {}", region);
-            try (LambdaClient lambdaClient = awsClientProvider.getLambdaClient(region)) {
+            try (LambdaClient lambdaClient = awsClientProvider.getLambdaClient(region, scrapeConfig.getAssumeRole())) {
                 GetAccountSettingsResponse accountSettings = rateLimiter.doWithRateLimit(
                         "LambdaClient/getAccountSettings",
                         ImmutableSortedMap.of(

--- a/src/main/java/ai/asserts/aws/exporter/LambdaEventSourceExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/LambdaEventSourceExporter.java
@@ -1,4 +1,3 @@
-
 package ai.asserts.aws.exporter;
 
 import ai.asserts.aws.AWSClientProvider;
@@ -78,7 +77,7 @@ public class LambdaEventSourceExporter extends Collector implements MetricProvid
         Map<String, List<EventSourceMappingConfiguration>> byRegion = new TreeMap<>();
         ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
         scrapeConfig.getLambdaConfig().ifPresent(namespaceConfig -> scrapeConfig.getRegions().forEach(region -> {
-            try (LambdaClient client = awsClientProvider.getLambdaClient(region)) {
+            try (LambdaClient client = awsClientProvider.getLambdaClient(region, scrapeConfig.getAssumeRole())) {
                 // Get all event source mappings
                 log.info("Discovering Lambda event source mappings for region={}", region);
                 String nextToken = null;

--- a/src/main/java/ai/asserts/aws/exporter/LambdaInvokeConfigExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/LambdaInvokeConfigExporter.java
@@ -80,7 +80,7 @@ public class LambdaInvokeConfigExporter extends Collector implements MetricProvi
         ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
         Optional<NamespaceConfig> opt = scrapeConfig.getLambdaConfig();
         opt.ifPresent(ns -> fnScraper.getFunctions().forEach((region, byARN) -> byARN.forEach((arn, fnConfig) -> {
-            try (LambdaClient client = awsClientProvider.getLambdaClient(region)) {
+            try (LambdaClient client = awsClientProvider.getLambdaClient(region, scrapeConfig.getAssumeRole())) {
                 ListFunctionEventInvokeConfigsRequest request = ListFunctionEventInvokeConfigsRequest.builder()
                         .functionName(fnConfig.getName())
                         .build();

--- a/src/main/java/ai/asserts/aws/exporter/LambdaLogMetricScrapeTask.java
+++ b/src/main/java/ai/asserts/aws/exporter/LambdaLogMetricScrapeTask.java
@@ -1,4 +1,3 @@
-
 package ai.asserts.aws.exporter;
 
 import ai.asserts.aws.AWSClientProvider;
@@ -81,7 +80,8 @@ public class LambdaLogMetricScrapeTask extends Collector implements MetricProvid
         scrapeConfig.getLambdaConfig().ifPresent(nc -> {
             log.info("BEGIN lambda log scrape for region {}", region);
             if (!CollectionUtils.isEmpty(nc.getLogs()) && lambdaFunctionScraper.getFunctions().containsKey(region)) {
-                try (CloudWatchLogsClient cloudWatchLogsClient = awsClientProvider.getCloudWatchLogsClient(region)) {
+                try (CloudWatchLogsClient cloudWatchLogsClient = awsClientProvider.getCloudWatchLogsClient(region,
+                        scrapeConfig.getAssumeRole())) {
                     lambdaFunctionScraper.getFunctions().get(region).forEach((arn, functionConfig) -> nc.getLogs()
                             .stream()
                             .filter(logScrapeConfig -> logScrapeConfig.shouldScrapeLogsFor(functionConfig.getName()))
@@ -104,19 +104,19 @@ public class LambdaLogMetricScrapeTask extends Collector implements MetricProvid
         return map;
     }
 
-    @Builder
-    @EqualsAndHashCode
-    @Getter
-    public static class FunctionLogScrapeConfig {
-        private final LambdaFunction lambdaFunction;
-        private final LogScrapeConfig logScrapeConfig;
-    }
-
     private void sleep(long time) {
         try {
             Thread.sleep(time);
         } catch (InterruptedException e) {
             log.error("Interrupted", e);
         }
+    }
+
+    @Builder
+    @EqualsAndHashCode
+    @Getter
+    public static class FunctionLogScrapeConfig {
+        private final LambdaFunction lambdaFunction;
+        private final LogScrapeConfig logScrapeConfig;
     }
 }

--- a/src/main/java/ai/asserts/aws/exporter/ResourceExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ResourceExporter.java
@@ -79,7 +79,8 @@ public class ResourceExporter extends Collector implements MetricProvider {
             if (discoverResourceTypes.size() > 0) {
                 scrapeConfig.getRegions().forEach(region -> {
                     log.info("Discovering resources in region {}", region);
-                    try (ConfigClient configClient = awsClientProvider.getConfigClient(region)) {
+                    try (ConfigClient configClient = awsClientProvider.getConfigClient(region,
+                            scrapeConfig.getAssumeRole())) {
                         discoverResourceTypes.forEach(resourceType ->
                                 samples.addAll(getResources(region, configClient, resourceType)));
                     }

--- a/src/main/java/ai/asserts/aws/lambda/LambdaFunctionScraper.java
+++ b/src/main/java/ai/asserts/aws/lambda/LambdaFunctionScraper.java
@@ -1,4 +1,3 @@
-
 package ai.asserts.aws.lambda;
 
 import ai.asserts.aws.AWSClientProvider;
@@ -61,7 +60,7 @@ public class LambdaFunctionScraper {
                 .filter(ns -> CWNamespace.lambda.getNamespace().equals(ns.getName()))
                 .findFirst();
         lambdaNSOpt.ifPresent(lambdaNS -> scrapeConfig.getRegions().forEach(region -> {
-            try (LambdaClient lambdaClient = awsClientProvider.getLambdaClient(region)) {
+            try (LambdaClient lambdaClient = awsClientProvider.getLambdaClient(region, scrapeConfig.getAssumeRole())) {
                 // Get all the functions
                 ListFunctionsResponse response = rateLimiter.doWithRateLimit(
                         "LambdaClient/listFunctions",

--- a/src/main/java/ai/asserts/aws/resource/ResourceTagHelper.java
+++ b/src/main/java/ai/asserts/aws/resource/ResourceTagHelper.java
@@ -156,7 +156,8 @@ public class ResourceTagHelper {
         ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
         Set<Resource> resources = new HashSet<>();
         String nextToken = null;
-        try (ResourceGroupsTaggingApiClient client = awsClientProvider.getResourceTagClient(region)) {
+        try (ResourceGroupsTaggingApiClient client = awsClientProvider.getResourceTagClient(region,
+                scrapeConfig.getAssumeRole())) {
             do {
                 GetResourcesRequest req = builder
                         .paginationToken(nextToken)
@@ -202,7 +203,8 @@ public class ResourceTagHelper {
         }
         if (resourceType.equals("AWS::ElasticLoadBalancing::LoadBalancer")) {
             ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
-            try (ElasticLoadBalancingClient elbClient = awsClientProvider.getELBClient(region)) {
+            try (ElasticLoadBalancingClient elbClient = awsClientProvider.getELBClient(region,
+                    scrapeConfig.getAssumeRole())) {
                 DescribeTagsResponse describeTagsResponse = elbClient.describeTags(DescribeTagsRequest.builder()
                         .loadBalancerNames(resourceNames)
                         .build());
@@ -216,7 +218,8 @@ public class ResourceTagHelper {
                                 .collect(Collectors.toList())));
             }
         } else if (resourceType.equals("AWS::AutoScaling::AutoScalingGroup")) {
-            try (AutoScalingClient asgClient = awsClientProvider.getAutoScalingClient(region)) {
+            try (AutoScalingClient asgClient = awsClientProvider.getAutoScalingClient(region,
+                    scrapeConfigProvider.getScrapeConfig().getAssumeRole())) {
                 software.amazon.awssdk.services.autoscaling.model.DescribeTagsResponse describeTagsResponse = asgClient.describeTags(software.amazon.awssdk.services.autoscaling.model.DescribeTagsRequest.builder()
                         .build());
                 describeTagsResponse.tags()

--- a/src/test/java/ai/asserts/aws/MetricTaskManagerTest.java
+++ b/src/test/java/ai/asserts/aws/MetricTaskManagerTest.java
@@ -59,7 +59,7 @@ public class MetricTaskManagerTest extends EasyMockSupport {
         testClass = new MetricTaskManager(collectorRegistry, beanFactory, scrapeConfigProvider, ecsServiceDiscoveryExporter,
                 taskThreadPool, alarmMetricExporter, alarmFetcher) {
             @Override
-            MetricScrapeTask newScrapeTask(String region, Integer interval, Integer delay) {
+            MetricScrapeTask newScrapeTask(String region, Integer interval, Integer delay, String assumeRole) {
                 return metricScrapeTask;
             }
         };
@@ -74,6 +74,7 @@ public class MetricTaskManagerTest extends EasyMockSupport {
 
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
         expect(scrapeConfig.getDelay()).andReturn(delay).anyTimes();
+        expect(scrapeConfig.getAssumeRole()).andReturn(null).anyTimes();
 
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region1", "region2")).anyTimes();
         ImmutableList<LogScrapeConfig> logScrapeConfigs = ImmutableList.of(LogScrapeConfig.builder()

--- a/src/test/java/ai/asserts/aws/cloudwatch/TimeWindowBuilderTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/TimeWindowBuilderTest.java
@@ -10,6 +10,12 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+import java.time.zone.ZoneRules;
+import java.util.Date;
+import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -27,9 +33,14 @@ public class TimeWindowBuilderTest {
     void getDailyTimePeriod_us_west_2() {
         TimeWindowBuilder testClass = new TimeWindowBuilder();
         Instant[] timePeriod = testClass.getDailyMetricTimeWindow("us-west-2");
+        ZonedDateTime currentTime = testClass.getZonedDateTime("us-west-2");
+        ZoneRules zoneRules = currentTime.getZone().getRules();
+        if( zoneRules.isDaylightSavings( currentTime.toInstant() )){
+            timePeriod[0] = timePeriod[0].plus(1, ChronoUnit.HOURS);
+            timePeriod[1] = timePeriod[1].plus(1, ChronoUnit.HOURS);
+        }
         ZonedDateTime startTime = ZonedDateTime.ofInstant(timePeriod[0], ZoneId.of("America/Los_Angeles"));
         ZonedDateTime endTime = ZonedDateTime.ofInstant(timePeriod[1], ZoneId.of("America/Los_Angeles"));
-
         assertEquals(0, startTime.getSecond());
         assertEquals(0, startTime.getMinute());
         assertEquals(0, startTime.getHour());

--- a/src/test/java/ai/asserts/aws/cloudwatch/alarms/AlarmFetcherTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/alarms/AlarmFetcherTest.java
@@ -63,9 +63,10 @@ public class AlarmFetcherTest extends EasyMockSupport {
     @Test
     public void sendAlarmsForRegions() {
         expect(accountIDProvider.getAccountId()).andReturn("123456789").anyTimes();
-        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).times(2);
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region")).anyTimes();
-        expect(awsClientProvider.getCloudWatchClient("region")).andReturn(cloudWatchClient).anyTimes();
+        expect(scrapeConfig.getAssumeRole()).andReturn(null);
+        expect(awsClientProvider.getCloudWatchClient("region", null)).andReturn(cloudWatchClient).anyTimes();
 
 
         Capture<RateLimiter.AWSAPICall<DescribeAlarmsResponse>> callbackCapture = Capture.newInstance();

--- a/src/test/java/ai/asserts/aws/cloudwatch/query/MetricQueryProviderTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/query/MetricQueryProviderTest.java
@@ -1,4 +1,3 @@
-
 package ai.asserts.aws.cloudwatch.query;
 
 import ai.asserts.aws.AWSClientProvider;
@@ -33,6 +32,8 @@ import static org.easymock.EasyMock.anyObject;
 import static org.easymock.EasyMock.expect;
 
 public class MetricQueryProviderTest extends EasyMockSupport {
+    private final CWNamespace _CW_namespace = lambda;
+    private final String metricName = "Invocations";
     private ScrapeConfigProvider scrapeConfigProvider;
     private QueryIdGenerator queryIdGenerator;
     private MetricNameUtil metricNameUtil;
@@ -47,8 +48,6 @@ public class MetricQueryProviderTest extends EasyMockSupport {
     private MetricQuery metricQuery;
     private BasicMetricCollector metricCollector;
     private MetricQueryProvider testClass;
-    private final CWNamespace _CW_namespace = lambda;
-    private final String metricName = "Invocations";
 
     @BeforeEach
     public void setup() {
@@ -90,7 +89,7 @@ public class MetricQueryProviderTest extends EasyMockSupport {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
         expect(scrapeConfigProvider.getStandardNamespace(_CW_namespace.name()))
                 .andReturn(Optional.of(lambda)).anyTimes();
-        expect(awsClientProvider.getCloudWatchClient("region1")).andReturn(cloudWatchClient);
+        expect(awsClientProvider.getCloudWatchClient("region1", null)).andReturn(cloudWatchClient);
 
         expect(namespaceConfig.hasTagFilters()).andReturn(true).anyTimes();
 
@@ -145,7 +144,7 @@ public class MetricQueryProviderTest extends EasyMockSupport {
                 .build();
 
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
-        expect(awsClientProvider.getCloudWatchClient("region1")).andReturn(cloudWatchClient);
+        expect(awsClientProvider.getCloudWatchClient("region1", null)).andReturn(cloudWatchClient);
 
         expect(namespaceConfig.hasTagFilters()).andReturn(true).anyTimes();
 

--- a/src/test/java/ai/asserts/aws/exporter/AccountIDProviderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/AccountIDProviderTest.java
@@ -37,7 +37,8 @@ public class AccountIDProviderTest extends EasyMockSupport {
     public void afterPropertiesSet() {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region")).anyTimes();
-        expect(awsClientProvider.getStsClient("region")).andReturn(stsClient);
+        expect(scrapeConfig.getAssumeRole()).andReturn(null).anyTimes();
+        expect(awsClientProvider.getStsClient("region", null)).andReturn(stsClient);
         expect(stsClient.getCallerIdentity()).andReturn(GetCallerIdentityResponse.builder()
                 .account("TestAccount")
                 .build());

--- a/src/test/java/ai/asserts/aws/exporter/ApiGatewayToLambdaBuilderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ApiGatewayToLambdaBuilderTest.java
@@ -54,7 +54,8 @@ public class ApiGatewayToLambdaBuilderTest extends EasyMockSupport {
                 new RateLimiter(metricCollector), accountIDProvider);
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region"));
-        expect(awsClientProvider.getApiGatewayClient("region")).andReturn(apiGatewayClient).anyTimes();
+        expect(scrapeConfig.getAssumeRole()).andReturn(null);
+        expect(awsClientProvider.getApiGatewayClient("region", null)).andReturn(apiGatewayClient).anyTimes();
         expect(accountIDProvider.getAccountId()).andReturn("account").anyTimes();
     }
 

--- a/src/test/java/ai/asserts/aws/exporter/EC2ToEBSVolumeExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/EC2ToEBSVolumeExporterTest.java
@@ -47,9 +47,10 @@ public class EC2ToEBSVolumeExporterTest extends EasyMockSupport {
         testClass = new EC2ToEBSVolumeExporter(
                 accountIDProvider, scrapeConfigProvider, awsClientProvider, new RateLimiter(metricCollector)
         );
-        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).times(2);
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region"));
-        expect(awsClientProvider.getEc2Client("region")).andReturn(ec2Client);
+        expect(scrapeConfig.getAssumeRole()).andReturn(null);
+        expect(awsClientProvider.getEc2Client("region", null)).andReturn(ec2Client);
         expect(accountIDProvider.getAccountId()).andReturn("account").anyTimes();
     }
 

--- a/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
@@ -93,11 +93,12 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
     @Test
     public void run() throws Exception {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfig.getAssumeRole()).andReturn(null).times(2);
         expect(scrapeConfig.getEcsTargetSDFile()).andReturn("ecs-sd-file.yml");
         expect(scrapeConfig.isDiscoverECSTasks()).andReturn(true);
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region1", "region2"));
 
-        expect(awsClientProvider.getECSClient("region1")).andReturn(ecsClient);
+        expect(awsClientProvider.getECSClient("region1", null)).andReturn(ecsClient);
         expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
                 .clusterArns("arn1", "arn2")
                 .build());
@@ -105,7 +106,7 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
         expect(resourceMapper.map("arn1")).andReturn(Optional.of(resource));
         expect(resourceMapper.map("arn2")).andReturn(Optional.of(resource));
 
-        expect(awsClientProvider.getECSClient("region2")).andReturn(ecsClient);
+        expect(awsClientProvider.getECSClient("region2", null)).andReturn(ecsClient);
         expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
                 .clusterArns("arn3", "arn4")
                 .build());
@@ -141,11 +142,12 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
     @Test
     public void run_JacksonWriteException() throws Exception {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfig.getAssumeRole()).andReturn(null).times(2);
         expect(scrapeConfig.getEcsTargetSDFile()).andReturn("ecs-sd-file.yml");
         expect(scrapeConfig.isDiscoverECSTasks()).andReturn(true);
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region1", "region2"));
 
-        expect(awsClientProvider.getECSClient("region1")).andReturn(ecsClient);
+        expect(awsClientProvider.getECSClient("region1", null)).andReturn(ecsClient);
         expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
                 .clusterArns("arn1", "arn2")
                 .build());
@@ -153,7 +155,7 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
         expect(resourceMapper.map("arn1")).andReturn(Optional.of(resource));
         expect(resourceMapper.map("arn2")).andReturn(Optional.of(resource));
 
-        expect(awsClientProvider.getECSClient("region2")).andReturn(ecsClient);
+        expect(awsClientProvider.getECSClient("region2", null)).andReturn(ecsClient);
         expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
                 .clusterArns("arn3", "arn4")
                 .build());
@@ -191,16 +193,17 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
     @Test
     public void run_AWSException() throws Exception {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfig.getAssumeRole()).andReturn(null).times(2);
         expect(scrapeConfig.getEcsTargetSDFile()).andReturn("ecs-sd-file.yml");
         expect(scrapeConfig.isDiscoverECSTasks()).andReturn(true);
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region1", "region2"));
 
-        expect(awsClientProvider.getECSClient("region1")).andReturn(ecsClient);
+        expect(awsClientProvider.getECSClient("region1", null)).andReturn(ecsClient);
         expect(ecsClient.listClusters()).andThrow(new RuntimeException());
         metricCollector.recordLatency(anyString(), anyObject(), anyLong());
         metricCollector.recordCounterValue(eq(SCRAPE_ERROR_COUNT_METRIC), anyObject(), eq(1));
 
-        expect(awsClientProvider.getECSClient("region2")).andReturn(ecsClient);
+        expect(awsClientProvider.getECSClient("region2", null)).andReturn(ecsClient);
         expect(ecsClient.listClusters()).andThrow(new RuntimeException());
         metricCollector.recordLatency(anyString(), anyObject(), anyLong());
         metricCollector.recordCounterValue(eq(SCRAPE_ERROR_COUNT_METRIC), anyObject(), eq(1));

--- a/src/test/java/ai/asserts/aws/exporter/LBToASGRelationBuilderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/LBToASGRelationBuilderTest.java
@@ -58,11 +58,12 @@ public class LBToASGRelationBuilderTest extends EasyMockSupport {
 
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region"));
+        expect(scrapeConfig.getAssumeRole()).andReturn(null);
     }
 
     @Test
     void updateRouting() {
-        expect(awsClientProvider.getAutoScalingClient("region")).andReturn(autoScalingClient);
+        expect(awsClientProvider.getAutoScalingClient("region", null)).andReturn(autoScalingClient);
         expect(autoScalingClient.describeAutoScalingGroups()).andReturn(DescribeAutoScalingGroupsResponse.builder()
                 .autoScalingGroups(AutoScalingGroup.builder()
                         .autoScalingGroupARN("asg-arn")

--- a/src/test/java/ai/asserts/aws/exporter/LBToLambdaRoutingBuilderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/LBToLambdaRoutingBuilderTest.java
@@ -64,7 +64,8 @@ public class LBToLambdaRoutingBuilderTest extends EasyMockSupport {
         expect(accountIDProvider.getAccountId()).andReturn("account").anyTimes();
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region")).anyTimes();
-        expect(awsClientProvider.getELBV2Client("region")).andReturn(elbV2Client).anyTimes();
+        expect(scrapeConfig.getAssumeRole()).andReturn(null).anyTimes();
+        expect(awsClientProvider.getELBV2Client("region", null)).andReturn(elbV2Client).anyTimes();
         expect(targetGroupLBMapProvider.getTgToLB()).andReturn(ImmutableMap.of(targetResource, lbRsource));
     }
 

--- a/src/test/java/ai/asserts/aws/exporter/LambdaEventSourceExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/LambdaEventSourceExporterTest.java
@@ -1,4 +1,3 @@
-
 package ai.asserts.aws.exporter;
 
 import ai.asserts.aws.AWSClientProvider;
@@ -71,7 +70,7 @@ public class LambdaEventSourceExporterTest extends EasyMockSupport {
         ).anyTimes();
 
         AWSClientProvider awsClientProvider = mock(AWSClientProvider.class);
-        expect(awsClientProvider.getLambdaClient("region1")).andReturn(lambdaClient).anyTimes();
+        expect(awsClientProvider.getLambdaClient("region1", null)).andReturn(lambdaClient).anyTimes();
 
         testClass = new LambdaEventSourceExporter(scrapeConfigProvider, awsClientProvider,
                 metricNameUtil, resourceMapper, resourceTagHelper, sampleBuilder,

--- a/src/test/java/ai/asserts/aws/exporter/LambdaInvokeConfigExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/LambdaInvokeConfigExporterTest.java
@@ -71,13 +71,14 @@ public class LambdaInvokeConfigExporterTest extends EasyMockSupport {
                 scrapeConfigProvider, resourceMapper, metricSampleBuilder, new RateLimiter(metricCollector));
 
         expect(scrapeConfig.getLambdaConfig()).andReturn(Optional.of(namespaceConfig));
+        expect(scrapeConfig.getAssumeRole()).andReturn(null);
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
         expect(metricNameUtil.getMetricPrefix(CWNamespace.lambda.getNamespace())).andReturn("prefix");
     }
 
     @Test
     void collect() {
-        expect(awsClientProvider.getLambdaClient("region1")).andReturn(lambdaClient);
+        expect(awsClientProvider.getLambdaClient("region1", null)).andReturn(lambdaClient);
 
         ListFunctionEventInvokeConfigsRequest request = ListFunctionEventInvokeConfigsRequest.builder()
                 .functionName("fn1")

--- a/src/test/java/ai/asserts/aws/exporter/LambdaLogMetricScrapeTaskTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/LambdaLogMetricScrapeTaskTest.java
@@ -1,4 +1,3 @@
-
 package ai.asserts.aws.exporter;
 
 import ai.asserts.aws.AWSClientProvider;
@@ -72,6 +71,7 @@ public class LambdaLogMetricScrapeTaskTest extends EasyMockSupport {
     void scrape_whenLambdaEnabled() {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
         expect(scrapeConfig.getLambdaConfig()).andReturn(Optional.of(namespaceConfig)).anyTimes();
+        expect(scrapeConfig.getAssumeRole()).andReturn(null).anyTimes();
         expect(scrapeConfig.getLogScrapeDelaySeconds()).andReturn(1);
         expect(namespaceConfig.getLogs()).andReturn(ImmutableList.of(logScrapeConfig)).anyTimes();
         expect(lambdaFunctionScraper.getFunctions()).andReturn(ImmutableMap.of(
@@ -79,7 +79,7 @@ public class LambdaLogMetricScrapeTaskTest extends EasyMockSupport {
         ).anyTimes();
         expect(lambdaFunction.getName()).andReturn("fn1").anyTimes();
         expect(logScrapeConfig.shouldScrapeLogsFor("fn1")).andReturn(true);
-        expect(awsClientProvider.getCloudWatchLogsClient(region)).andReturn(cloudWatchLogsClient);
+        expect(awsClientProvider.getCloudWatchLogsClient(region, null)).andReturn(cloudWatchLogsClient);
         FilteredLogEvent filteredLogEvent = FilteredLogEvent.builder()
                 .message("message")
                 .build();

--- a/src/test/java/ai/asserts/aws/exporter/MetricScrapeTaskTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/MetricScrapeTaskTest.java
@@ -1,4 +1,3 @@
-
 package ai.asserts.aws.exporter;
 
 import ai.asserts.aws.AWSClientProvider;
@@ -67,7 +66,7 @@ public class MetricScrapeTaskTest extends EasyMockSupport {
         familySamples = mock(Collector.MetricFamilySamples.class);
         timeWindowBuilder = mock(TimeWindowBuilder.class);
 
-        testClass = new MetricScrapeTask(region, interval, delay);
+        testClass = new MetricScrapeTask(region, interval, delay, null);
         testClass.setMetricQueryProvider(metricQueryProvider);
         testClass.setQueryBatcher(queryBatcher);
         testClass.setAwsClientProvider(awsClientProvider);
@@ -104,7 +103,7 @@ public class MetricScrapeTaskTest extends EasyMockSupport {
         expect(metricQueryProvider.getMetricQueries())
                 .andReturn(ImmutableMap.of(region, ImmutableMap.of(interval, queries)));
 
-        expect(awsClientProvider.getCloudWatchClient(region)).andReturn(cloudWatchClient);
+        expect(awsClientProvider.getCloudWatchClient(region, null)).andReturn(cloudWatchClient);
 
         expect(timeWindowBuilder.getTimePeriod(region, interval)).andReturn(new Instant[]{now.minusSeconds(60), now});
 

--- a/src/test/java/ai/asserts/aws/exporter/ResourceExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ResourceExporterTest.java
@@ -90,7 +90,8 @@ public class ResourceExporterTest extends EasyMockSupport {
         expect(scrapeConfig.getDiscoverResourceTypes()).andReturn(ImmutableSet.of("type1")).anyTimes();
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region")).anyTimes();
         expect(scrapeConfig.getTagExportConfig()).andReturn(tagExportConfig).anyTimes();
-        expect(awsClientProvider.getConfigClient("region")).andReturn(configClient).anyTimes();
+        expect(awsClientProvider.getConfigClient("region", null)).andReturn(configClient).anyTimes();
+        expect(scrapeConfig.getAssumeRole()).andReturn(null).anyTimes();
 
         Capture<RateLimiter.AWSAPICall<ListDiscoveredResourcesResponse>> callbackCapture = Capture.newInstance();
 

--- a/src/test/java/ai/asserts/aws/exporter/TargetGroupLBMapProviderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/TargetGroupLBMapProviderTest.java
@@ -65,6 +65,7 @@ public class TargetGroupLBMapProviderTest extends EasyMockSupport {
 
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region")).anyTimes();
+        expect(scrapeConfig.getAssumeRole()).andReturn(null).anyTimes();
     }
 
     @Test
@@ -73,7 +74,7 @@ public class TargetGroupLBMapProviderTest extends EasyMockSupport {
                 .loadBalancerArn("lb-arn")
                 .build();
 
-        expect(awsClientProvider.getELBV2Client("region")).andReturn(lbClient);
+        expect(awsClientProvider.getELBV2Client("region", null)).andReturn(lbClient);
 
         expect(lbClient.describeLoadBalancers()).andReturn(DescribeLoadBalancersResponse.builder()
                 .loadBalancers(loadBalancer)

--- a/src/test/java/ai/asserts/aws/lambda/LambdaFunctionScraperTest.java
+++ b/src/test/java/ai/asserts/aws/lambda/LambdaFunctionScraperTest.java
@@ -1,4 +1,3 @@
-
 package ai.asserts.aws.lambda;
 
 import ai.asserts.aws.AWSClientProvider;
@@ -97,7 +96,7 @@ public class LambdaFunctionScraperTest extends EasyMockSupport {
                 .functionName("fn4")
                 .build();
 
-        expect(awsClientProvider.getLambdaClient("region1")).andReturn(lambdaClient);
+        expect(awsClientProvider.getLambdaClient("region1", null)).andReturn(lambdaClient);
 
         expect(lambdaClient.listFunctions()).andReturn(ListFunctionsResponse.builder()
                 .functions(ImmutableList.of(fn1Config, fn2Config)).build());
@@ -111,7 +110,7 @@ public class LambdaFunctionScraperTest extends EasyMockSupport {
         metricCollector.recordLatency(anyString(), anyObject(), anyLong());
         lambdaClient.close();
 
-        expect(awsClientProvider.getLambdaClient("region2")).andReturn(lambdaClient);
+        expect(awsClientProvider.getLambdaClient("region2", null)).andReturn(lambdaClient);
 
         expect(lambdaClient.listFunctions()).andReturn(ListFunctionsResponse.builder()
                 .functions(ImmutableList.of(fn3Config, fn4Config)).build());
@@ -127,8 +126,8 @@ public class LambdaFunctionScraperTest extends EasyMockSupport {
         replayAll();
 
         assertEquals(ImmutableMap.of(
-                "region1", ImmutableMap.of("arn1", lambdaFunction, "arn2", lambdaFunction),
-                "region2", ImmutableMap.of("arn3", lambdaFunction, "arn4", lambdaFunction)
+                        "region1", ImmutableMap.of("arn1", lambdaFunction, "arn2", lambdaFunction),
+                        "region2", ImmutableMap.of("arn3", lambdaFunction, "arn4", lambdaFunction)
                 ),
                 lambdaFunctionScraper.getFunctions());
 
@@ -137,11 +136,11 @@ public class LambdaFunctionScraperTest extends EasyMockSupport {
 
     @Test
     public void getFunctions_Exception() {
-        expect(awsClientProvider.getLambdaClient("region1")).andReturn(lambdaClient);
+        expect(awsClientProvider.getLambdaClient("region1", null)).andReturn(lambdaClient);
         expect(lambdaClient.listFunctions()).andThrow(new RuntimeException());
         lambdaClient.close();
 
-        expect(awsClientProvider.getLambdaClient("region2")).andReturn(lambdaClient);
+        expect(awsClientProvider.getLambdaClient("region2", null)).andReturn(lambdaClient);
         expect(lambdaClient.listFunctions()).andThrow(new RuntimeException());
         metricCollector.recordCounterValue(eq(SCRAPE_ERROR_COUNT_METRIC), anyObject(SortedMap.class), eq(1));
         expectLastCall().times(2);

--- a/src/test/java/ai/asserts/aws/resource/ResourceTagHelperTest.java
+++ b/src/test/java/ai/asserts/aws/resource/ResourceTagHelperTest.java
@@ -87,7 +87,8 @@ public class ResourceTagHelperTest extends EasyMockSupport {
         expect(namespaceConfig.getTagFilters()).andReturn(ImmutableMap.of(
                 "tag", ImmutableSortedSet.of("value1", "value2")
         ));
-        expect(awsClientProvider.getResourceTagClient("region")).andReturn(apiClient);
+        expect(awsClientProvider.getResourceTagClient("region", null)).andReturn(apiClient);
+        expect(scrapeConfig.getAssumeRole()).andReturn(null);
 
         Tag tag1 = Tag.builder()
                 .key("tag").value("value1")
@@ -152,7 +153,8 @@ public class ResourceTagHelperTest extends EasyMockSupport {
         expect(scrapeConfigProvider.getStandardNamespace("kafka")).andReturn(Optional.of(kafka));
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
         expect(namespaceConfig.hasTagFilters()).andReturn(false);
-        expect(awsClientProvider.getResourceTagClient("region")).andReturn(apiClient);
+        expect(awsClientProvider.getResourceTagClient("region", null)).andReturn(apiClient);
+        expect(scrapeConfig.getAssumeRole()).andReturn(null);
 
         Tag tag1 = Tag.builder()
                 .key("tag").value("value1")
@@ -264,7 +266,7 @@ public class ResourceTagHelperTest extends EasyMockSupport {
 
         expect(resource.getTags()).andReturn(tags).anyTimes();
 
-        expect(awsClientProvider.getELBClient("region")).andReturn(elbClient);
+        expect(awsClientProvider.getELBClient("region", null)).andReturn(elbClient);
         expect(elbClient.describeTags(DescribeTagsRequest.builder()
                 .loadBalancerNames("resourceName")
                 .build())).andReturn(DescribeTagsResponse.builder()
@@ -279,6 +281,7 @@ public class ResourceTagHelperTest extends EasyMockSupport {
         resource.setTags(ImmutableList.of(lbTagConverted, resourceTag));
 
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
+        expect(scrapeConfig.getAssumeRole()).andReturn(null);
         expect(scrapeConfig.shouldExportTag(lbTagConverted)).andReturn(true);
         replayAll();
 


### PR DESCRIPTION
When assumeRole property is configured use sts client to assume the role and get credential for the session.
Use Session Credential to get client to perform any operations.
[ch11424]