### PR TITLE
Adding job label

### DIFF
--- a/src/main/java/ai/asserts/aws/exporter/KinesisFirehoseExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/KinesisFirehoseExporter.java
@@ -93,6 +93,9 @@ public class KinesisFirehoseExporter extends Collector implements InitializingBe
                                 resource.addLabels(labels, "");
                                 labels.put("aws_resource_type", labels.get("type"));
                                 labels.remove("type");
+                                if (labels.containsKey("name")) {
+                                    labels.put("job", labels.get("name"));
+                                }
                                 return sampleBuilder.buildSingleSample("aws_resource", labels, 1.0D);
                             })
                             .collect(Collectors.toList()));


### PR DESCRIPTION
For Kinesis firehose resource job label mapping was missing which used in entities mapping. Adding it to be used for entity mapping.
[ch11455]