### PR TITLE
Read scrape config from api-server

### DIFF
--- a/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProvider.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProvider.java
@@ -52,9 +52,9 @@ public class ScrapeConfigProvider {
     private final ResourceLoader resourceLoader = new FileSystemResourceLoader();
     private final ScrapeConfig NOOP_CONFIG = new ScrapeConfig();
     private final RestTemplate restTemplate;
-    private final String ASSERT_HOST = "ASSERT_HOST";
-    private final String ASSERT_USER = "ASSERT_USER";
-    private final String ASSERT_SECRET_KEY = "ASSERT_SECRET_KEY";
+    private final String ASSERTS_HOST = "ASSERTS_HOST";
+    private final String ASSERTS_USER = "ASSERTS_USER";
+    private final String ASSERTS_PASSWORD = "ASSERTS_PASSWORD";
     private volatile ScrapeConfig configCache;
 
 
@@ -106,11 +106,11 @@ public class ScrapeConfigProvider {
     }
 
     private ScrapeConfig getConfig(Map<String, String> envVariables) {
-        String host = envVariables.get(ASSERT_HOST);
-        String user = envVariables.get(ASSERT_USER);
-        String key = envVariables.get(ASSERT_SECRET_KEY);
+        String host = envVariables.get(ASSERTS_HOST);
+        String user = envVariables.get(ASSERTS_USER);
+        String key = envVariables.get(ASSERTS_PASSWORD);
         String url = host + "/api-server/v1/config/aws-exporter";
-        log.info("Will load configuration from server [{}] and user [{}]", host, user);
+        log.info("Will load configuration from server [{}] with credentials of user [{}]", host, user);
         ResponseEntity<ScrapeConfig> response = restTemplate.exchange(url,
                 HttpMethod.GET,
                 createAuthHeader(user, key),
@@ -139,8 +139,8 @@ public class ScrapeConfigProvider {
         SortedMap<String, String> labels = new TreeMap<>(ImmutableMap.of(SCRAPE_OPERATION_LABEL, "loadConfig"));
         try {
             Map<String, String> envVariables = getGetenv();
-            if (envVariables.containsKey(ASSERT_HOST) && envVariables.containsKey(ASSERT_USER)
-                    && envVariables.containsKey(ASSERT_SECRET_KEY)) {
+            if (envVariables.containsKey(ASSERTS_HOST) && envVariables.containsKey(ASSERTS_USER)
+                    && envVariables.containsKey(ASSERTS_PASSWORD)) {
                 scrapeConfig = getConfig(envVariables);
             } else if (envVariables.containsKey("CONFIG_S3_BUCKET") && envVariables.containsKey("CONFIG_S3_KEY")) {
                 labels.put(SCRAPE_OPERATION_LABEL, "loadConfigFromS3");

--- a/src/test/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProviderTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProviderTest.java
@@ -1,6 +1,5 @@
 package ai.asserts.aws.cloudwatch.config;
 
-import ai.asserts.aws.AWSClientProvider;
 import ai.asserts.aws.ObjectMapperFactory;
 import ai.asserts.aws.RateLimiter;
 import ai.asserts.aws.cloudwatch.model.MetricStat;
@@ -12,6 +11,14 @@ import com.google.common.collect.ImmutableSet;
 import org.easymock.EasyMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -33,10 +40,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class ScrapeConfigProviderTest extends EasyMockSupport {
     private S3Client s3Client;
     private BasicMetricCollector metricCollector;
+    private RestTemplate restTemplate;
 
     @BeforeEach
     public void setup() {
         s3Client = mock(S3Client.class);
+        restTemplate = mock(RestTemplate.class);
         metricCollector = mock(BasicMetricCollector.class);
     }
 
@@ -129,7 +138,8 @@ public class ScrapeConfigProviderTest extends EasyMockSupport {
         ScrapeConfigProvider testClass = new ScrapeConfigProvider(
                 new ObjectMapperFactory(),
                 metricCollector, new RateLimiter(metricCollector),
-                "src/test/resources/cloudwatch_scrape_config.yml");
+                "src/test/resources/cloudwatch_scrape_config.yml",
+                restTemplate);
         assertNotNull(testClass.getScrapeConfig());
         assertEquals(ImmutableSet.of("us-west-2"), testClass.getScrapeConfig().getRegions());
         assertTrue(testClass.getScrapeConfig().isDiscoverECSTasks());
@@ -141,7 +151,8 @@ public class ScrapeConfigProviderTest extends EasyMockSupport {
         ScrapeConfigProvider testClass = new ScrapeConfigProvider(
                 new ObjectMapperFactory(),
                 metricCollector, new RateLimiter(metricCollector),
-                "src/test/resources/cloudwatch_scrape_config.yml") {
+                "src/test/resources/cloudwatch_scrape_config.yml",
+                restTemplate) {
             @Override
             Map<String, String> getGetenv() {
                 return ImmutableMap.of("REGIONS", "us-east-1,us-east-2", "ENABLE_ECS_SD", "false");
@@ -170,7 +181,8 @@ public class ScrapeConfigProviderTest extends EasyMockSupport {
         ScrapeConfigProvider testClass = new ScrapeConfigProvider(
                 new ObjectMapperFactory(),
                 metricCollector, new RateLimiter(metricCollector),
-                "src/test/resources/cloudwatch_scrape_config.yml") {
+                "src/test/resources/cloudwatch_scrape_config.yml",
+                restTemplate) {
             @Override
             Map<String, String> getGetenv() {
                 return ImmutableMap.of("CONFIG_S3_BUCKET", "bucket", "CONFIG_S3_KEY", "key");
@@ -180,6 +192,42 @@ public class ScrapeConfigProviderTest extends EasyMockSupport {
             S3Client getS3Client() {
                 return s3Client;
             }
+        };
+        assertEquals(scrapeConfig.toString(), testClass.getScrapeConfig().toString());
+        verifyAll();
+    }
+
+    @Test
+    void loadConfigFromAsserts() throws IOException {
+        FileInputStream fis = new FileInputStream("src/test/resources/cloudwatch_scrape_config.yml");
+        ScrapeConfig scrapeConfig = new ObjectMapperFactory().getObjectMapper().readValue(fis, new TypeReference<ScrapeConfig>() {
+        });
+        scrapeConfig.validateConfig();
+
+        fis = new FileInputStream("src/test/resources/cloudwatch_scrape_config.yml");
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBasicAuth("user", "key");
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<?> httpEntity = new HttpEntity<>(headers);
+        ResponseEntity<ScrapeConfig> response = new ResponseEntity(scrapeConfig, HttpStatus.OK);
+        expect(restTemplate.exchange("host/api-server/v1/config/aws-exporter",
+                HttpMethod.GET,
+                httpEntity,
+                new ParameterizedTypeReference<ScrapeConfig>() {
+                }
+        )).andReturn(response);
+        replayAll();
+        ScrapeConfigProvider testClass = new ScrapeConfigProvider(
+                new ObjectMapperFactory(),
+                metricCollector, new RateLimiter(metricCollector),
+                "src/test/resources/cloudwatch_scrape_config.yml",
+                restTemplate) {
+            @Override
+            Map<String, String> getGetenv() {
+                return ImmutableMap.of("ASSERT_HOST", "host", "ASSERT_USER", "user",
+                        "ASSERT_SECRET_KEY", "key");
+            }
+
         };
         assertEquals(scrapeConfig.toString(), testClass.getScrapeConfig().toString());
         verifyAll();

--- a/src/test/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProviderTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/config/ScrapeConfigProviderTest.java
@@ -224,8 +224,8 @@ public class ScrapeConfigProviderTest extends EasyMockSupport {
                 restTemplate) {
             @Override
             Map<String, String> getGetenv() {
-                return ImmutableMap.of("ASSERT_HOST", "host", "ASSERT_USER", "user",
-                        "ASSERT_SECRET_KEY", "key");
+                return ImmutableMap.of("ASSERTS_HOST", "host", "ASSERTS_USER", "user",
+                        "ASSERTS_PASSWORD", "key");
             }
 
         };

--- a/src/test/java/ai/asserts/aws/cloudwatch/metrics/MetricStreamProcessorTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/metrics/MetricStreamProcessorTest.java
@@ -22,6 +22,7 @@ import org.easymock.EasyMockSupport;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestTemplate;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.File;
@@ -45,6 +46,7 @@ public class MetricStreamProcessorTest extends EasyMockSupport {
     private static ExportMetricsServiceRequest request;
     private BasicMetricCollector metricCollector;
     private Collector.MetricFamilySamples metricFamilySamples;
+    private RestTemplate restTemplate;
 
     @BeforeAll
     public static void setupRequest() throws IOException {
@@ -61,6 +63,7 @@ public class MetricStreamProcessorTest extends EasyMockSupport {
         metricCollector = mock(BasicMetricCollector.class);
         metricStreamProcessor = new MetricStreamProcessor(collectorRegistry, metricConverter);
         metricStreamProcessor.setCollectorRegistry(collectorRegistry);
+        restTemplate = mock(RestTemplate.class);
     }
 
     @Test
@@ -97,7 +100,8 @@ public class MetricStreamProcessorTest extends EasyMockSupport {
                 new ObjectMapperFactory(),
                 metricCollector,
                 new RateLimiter(metricCollector),
-                "src/test/resources/cloudwatch_scrape_config.yml"
+                "src/test/resources/cloudwatch_scrape_config.yml",
+                restTemplate
         );
         MetricNameUtil metricNameUtil = new MetricNameUtil(scrapeConfigProvider);
         LambdaLabelConverter lambdaLabelConverter = new LambdaLabelConverter(metricNameUtil);


### PR DESCRIPTION
When assert host, user and secret key is defined, read scrape config from api-server end point else continue the usual flow.
[ch11574]