### PR TITLE
Process Resource Config change

### DIFF
--- a/src/main/java/ai/asserts/aws/MetricNameUtil.java
+++ b/src/main/java/ai/asserts/aws/MetricNameUtil.java
@@ -24,6 +24,7 @@ public class MetricNameUtil {
     public static final String SCRAPE_ACCOUNT_ID_LABEL = "account_id";
     public static final String SCRAPE_NAMESPACE_LABEL = "cw_namespace";
     public static final String SCRAPE_INTERVAL_LABEL = "interval";
+    public static final String EXPORTER_DELAY_SECONDS = "aws_exporter_delay_seconds";
 
     public String exportedMetricName(Metric metric, MetricStat metricStat) {
         String namespace = metric.namespace();

--- a/src/main/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricExporter.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricExporter.java
@@ -4,6 +4,7 @@
  */
 package ai.asserts.aws.cloudwatch.alarms;
 
+import ai.asserts.aws.MetricNameUtil;
 import ai.asserts.aws.exporter.BasicMetricCollector;
 import ai.asserts.aws.exporter.MetricSampleBuilder;
 import com.google.common.annotations.VisibleForTesting;
@@ -95,7 +96,7 @@ public class AlarmMetricExporter extends Collector {
         histoLabels.put("region", labels.get("region"));
         histoLabels.put("alertname", labels.get("alertname"));
         long diff = (now().toEpochMilli() - timestamp.toEpochMilli()) / 1000;
-        this.basicMetricCollector.recordHistogram("aws_exporter_delay_seconds", histoLabels, diff);
+        this.basicMetricCollector.recordHistogram(MetricNameUtil.EXPORTER_DELAY_SECONDS, histoLabels, diff);
     }
 
     @VisibleForTesting

--- a/src/main/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricExporter.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricExporter.java
@@ -95,7 +95,7 @@ public class AlarmMetricExporter extends Collector {
         histoLabels.put("region", labels.get("region"));
         histoLabels.put("alertname", labels.get("alertname"));
         long diff = (now().toEpochMilli() - timestamp.toEpochMilli()) / 1000;
-        this.basicMetricCollector.recordHistogram("aws_cw_alarm_delay_seconds", histoLabels, diff);
+        this.basicMetricCollector.recordHistogram("aws_exporter_delay_seconds", histoLabels, diff);
     }
 
     @VisibleForTesting

--- a/src/main/java/ai/asserts/aws/cloudwatch/metrics/MetricStreamController.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/metrics/MetricStreamController.java
@@ -127,7 +127,7 @@ public class MetricStreamController {
         histoLabels.put("region", labels.get("region"));
         histoLabels.put("metric_name", metric_name);
         long diff = (now().toEpochMilli() - timestamp) / 1000;
-        this.metricCollector.recordHistogram("aws_exporter_delay_seconds", histoLabels, diff);
+        this.metricCollector.recordHistogram(MetricNameUtil.EXPORTER_DELAY_SECONDS, histoLabels, diff);
     }
 
     @VisibleForTesting

--- a/src/main/java/ai/asserts/aws/resource/ResourceConfigController.java
+++ b/src/main/java/ai/asserts/aws/resource/ResourceConfigController.java
@@ -124,7 +124,7 @@ public class ResourceConfigController {
                 if (resource.isPresent()) {
                     labels.put("job", resource.get().getName());
                     labels.put("namespace", resource.get().getType().getCwNamespace().getNamespace());
-                    recordHistogram(labels, configChange.getTime());
+                    recordDelayHistogram(labels, configChange.getTime());
                     metricCollector.recordGaugeValue("aws_resource_config", labels, 1.0D);
                 }
             });
@@ -132,7 +132,7 @@ public class ResourceConfigController {
         }
     }
 
-    private void recordHistogram(Map<String, String> labels, String timestamp) {
+    private void recordDelayHistogram(Map<String, String> labels, String timestamp) {
         Instant observedTime = Instant.parse(timestamp);
         SortedMap<String, String> histoLabels = new TreeMap<>();
         histoLabels.put("namespace", labels.get("namespace"));

--- a/src/main/java/ai/asserts/aws/resource/ResourceConfigController.java
+++ b/src/main/java/ai/asserts/aws/resource/ResourceConfigController.java
@@ -5,10 +5,13 @@
 package ai.asserts.aws.resource;
 
 import ai.asserts.aws.ObjectMapperFactory;
-import ai.asserts.aws.cloudwatch.alarms.AlarmResponse;
 import ai.asserts.aws.cloudwatch.alarms.FirehoseEventRequest;
 import ai.asserts.aws.cloudwatch.alarms.RecordData;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfigProvider;
+import ai.asserts.aws.exporter.BasicMetricCollector;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -18,7 +21,12 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.Instant;
 import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -28,7 +36,11 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 public class ResourceConfigController {
     private static final String CONFIG_CHANGE_RESOURCE = "/receive-config-change/resource";
     private static final String CONFIG_CHANGE_SNS = "/receive-config-change/sns";
+    private static final String CREATE_CHANGE_TYPE = "CREATE";
     private final ObjectMapperFactory objectMapperFactory;
+    private final BasicMetricCollector metricCollector;
+    private final ResourceMapper resourceMapper;
+    private final ScrapeConfigProvider scrapeConfigProvider;
 
     @PostMapping(
             path = CONFIG_CHANGE_RESOURCE,
@@ -36,8 +48,7 @@ public class ResourceConfigController {
             consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<Object> resourceConfigChangePost(
             @RequestBody FirehoseEventRequest resourceConfig) {
-        processRequest(resourceConfig);
-        return ResponseEntity.ok("Completed");
+        return processRequest(resourceConfig);
     }
 
     @PutMapping(
@@ -46,8 +57,7 @@ public class ResourceConfigController {
             consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<Object> resourceConfigChangePut(
             @RequestBody FirehoseEventRequest resourceConfig) {
-        processRequest(resourceConfig);
-        return ResponseEntity.ok("Completed");
+        return processRequest(resourceConfig);
     }
 
     @PostMapping(
@@ -70,7 +80,7 @@ public class ResourceConfigController {
         return ResponseEntity.ok("Completed");
     }
 
-    private ResponseEntity<AlarmResponse> processRequest(FirehoseEventRequest firehoseEventRequest) {
+    private ResponseEntity<Object> processRequest(FirehoseEventRequest firehoseEventRequest) {
         try {
             if (!CollectionUtils.isEmpty(firehoseEventRequest.getRecords())) {
                 for (RecordData recordData : firehoseEventRequest.getRecords()) {
@@ -82,7 +92,7 @@ public class ResourceConfigController {
         } catch (Exception ex) {
             log.error("Error in processing {}-{}", ex.toString(), ex.getStackTrace());
         }
-        return ResponseEntity.ok(AlarmResponse.builder().status("Success").build());
+        return ResponseEntity.ok("Completed");
     }
 
     private void accept(RecordData data) {
@@ -92,8 +102,49 @@ public class ResourceConfigController {
             log.info("Resource {} - changeType {} - ResourceType {} - ResourceId {} ", String.join(",", configChange.getResources()),
                     configChange.getDetail().getConfigurationItemDiff().getChangeType(), configChange.getDetail().getConfigurationItem().getResourceType(),
                     configChange.getDetail().getConfigurationItem().getResourceId());
+            publishConfigChange(configChange);
         } catch (JsonProcessingException jsp) {
             log.error("Error processing JSON {}-{}", decodedData, jsp.getMessage());
         }
+    }
+
+    private void publishConfigChange(ResourceConfigChange configChange) {
+        ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
+        if (!CREATE_CHANGE_TYPE.equals(configChange.getDetail().getConfigurationItemDiff().getChangeType()) &&
+                scrapeConfig.getDiscoverResourceTypes().contains(configChange.getDetail().getConfigurationItem().
+                        getResourceType())
+                && !CollectionUtils.isEmpty(configChange.getResources())) {
+            configChange.getResources().forEach(r -> {
+                SortedMap<String, String> labels = new TreeMap<>();
+                labels.put("region", configChange.getRegion());
+                labels.put("account_id", configChange.getAccount());
+                labels.put("alertname", String.format("Config-%s", configChange.getDetail().getConfigurationItemDiff().getChangeType()));
+                labels.put("asserts_entity_type", "Service");
+                Optional<Resource> resource = resourceMapper.map(r);
+                if (resource.isPresent()) {
+                    labels.put("job", resource.get().getName());
+                    labels.put("namespace", resource.get().getType().getCwNamespace().getNamespace());
+                    recordHistogram(labels, configChange.getTime());
+                    metricCollector.recordGaugeValue("aws_resource_config", labels, 1.0D);
+                }
+            });
+
+        }
+    }
+
+    private void recordHistogram(Map<String, String> labels, String timestamp) {
+        Instant observedTime = Instant.parse(timestamp);
+        SortedMap<String, String> histoLabels = new TreeMap<>();
+        histoLabels.put("namespace", labels.get("namespace"));
+        histoLabels.put("region", labels.get("region"));
+        histoLabels.put("alertname", labels.get("alertname"));
+        histoLabels.put("job", labels.get("job"));
+        long diff = (now().toEpochMilli() - observedTime.toEpochMilli()) / 1000;
+        this.metricCollector.recordHistogram("aws_exporter_delay_seconds", histoLabels, diff);
+    }
+
+    @VisibleForTesting
+    Instant now() {
+        return Instant.now();
     }
 }

--- a/src/main/java/ai/asserts/aws/resource/ResourceConfigController.java
+++ b/src/main/java/ai/asserts/aws/resource/ResourceConfigController.java
@@ -4,6 +4,7 @@
  */
 package ai.asserts.aws.resource;
 
+import ai.asserts.aws.MetricNameUtil;
 import ai.asserts.aws.ObjectMapperFactory;
 import ai.asserts.aws.cloudwatch.alarms.FirehoseEventRequest;
 import ai.asserts.aws.cloudwatch.alarms.RecordData;
@@ -140,7 +141,7 @@ public class ResourceConfigController {
         histoLabels.put("alertname", labels.get("alertname"));
         histoLabels.put("job", labels.get("job"));
         long diff = (now().toEpochMilli() - observedTime.toEpochMilli()) / 1000;
-        this.metricCollector.recordHistogram("aws_exporter_delay_seconds", histoLabels, diff);
+        this.metricCollector.recordHistogram(MetricNameUtil.EXPORTER_DELAY_SECONDS, histoLabels, diff);
     }
 
     @VisibleForTesting

--- a/src/main/java/ai/asserts/aws/resource/ResourceType.java
+++ b/src/main/java/ai/asserts/aws/resource/ResourceType.java
@@ -40,6 +40,7 @@ public enum ResourceType {
 
     @Getter
     private String nameDimension;
+    @Getter
     private CWNamespace cwNamespace;
     private SortedSet<String> otherDimensions;
 

--- a/src/test/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricExporterTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricExporterTest.java
@@ -4,6 +4,7 @@
  */
 package ai.asserts.aws.cloudwatch.alarms;
 
+import ai.asserts.aws.MetricNameUtil;
 import ai.asserts.aws.exporter.BasicMetricCollector;
 import ai.asserts.aws.exporter.MetricSampleBuilder;
 import com.google.common.collect.ImmutableList;
@@ -74,7 +75,7 @@ public class AlarmMetricExporterTest extends EasyMockSupport {
                 .put("namespace", "n1")
                 .put("region", "us-west-2").build());
 
-        basicMetricCollector.recordHistogram("aws_exporter_delay_seconds", labels, now.minusSeconds(timestamp).getEpochSecond());
+        basicMetricCollector.recordHistogram(MetricNameUtil.EXPORTER_DELAY_SECONDS, labels, now.minusSeconds(timestamp).getEpochSecond());
         replayAll();
         addLabels("ALARM");
         assertEquals(1, testClass.getAlarmLabels().size());

--- a/src/test/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricExporterTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/alarms/AlarmMetricExporterTest.java
@@ -74,7 +74,7 @@ public class AlarmMetricExporterTest extends EasyMockSupport {
                 .put("namespace", "n1")
                 .put("region", "us-west-2").build());
 
-        basicMetricCollector.recordHistogram("aws_cw_alarm_delay_seconds", labels, now.minusSeconds(timestamp).getEpochSecond());
+        basicMetricCollector.recordHistogram("aws_exporter_delay_seconds", labels, now.minusSeconds(timestamp).getEpochSecond());
         replayAll();
         addLabels("ALARM");
         assertEquals(1, testClass.getAlarmLabels().size());

--- a/src/test/java/ai/asserts/aws/cloudwatch/metrics/MetricStreamControllerTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/metrics/MetricStreamControllerTest.java
@@ -82,7 +82,7 @@ public class MetricStreamControllerTest extends EasyMockSupport {
 
         metricCollector.recordGaugeValue("aws_firehose_m1_sum", metricLabels, 4.0);
         metricCollector.recordGaugeValue("aws_firehose_m1_count", metricLabels, 2.0);
-        metricCollector.recordHistogram("aws_exporter_delay_seconds", metricHistoLabels, -5);
+        metricCollector.recordHistogram(MetricNameUtil.EXPORTER_DELAY_SECONDS, metricHistoLabels, -5);
         labels = new HashMap<>();
         labels.put("unit", "Percent");
         labels.put("account_id", "123");

--- a/src/test/java/ai/asserts/aws/resource/ResourceConfigControllerTest.java
+++ b/src/test/java/ai/asserts/aws/resource/ResourceConfigControllerTest.java
@@ -4,6 +4,7 @@
  */
 package ai.asserts.aws.resource;
 
+import ai.asserts.aws.MetricNameUtil;
 import ai.asserts.aws.ObjectMapperFactory;
 import ai.asserts.aws.cloudwatch.alarms.FirehoseEventRequest;
 import ai.asserts.aws.cloudwatch.alarms.RecordData;
@@ -105,7 +106,7 @@ public class ResourceConfigControllerTest extends EasyMockSupport {
         histoLabels.put("namespace", "AWS/EC2");
         histoLabels.put("region", "r1");
         metricCollector.recordGaugeValue("aws_resource_config", labels, 1.0D);
-        metricCollector.recordHistogram("aws_exporter_delay_seconds", histoLabels, 5);
+        metricCollector.recordHistogram(MetricNameUtil.EXPORTER_DELAY_SECONDS, histoLabels, 5);
         replayAll();
         assertEquals(HttpStatus.OK, testClass.resourceConfigChangePost(resourceConfig).getStatusCode());
         verifyAll();

--- a/src/test/java/ai/asserts/aws/resource/ResourceConfigControllerTest.java
+++ b/src/test/java/ai/asserts/aws/resource/ResourceConfigControllerTest.java
@@ -1,0 +1,113 @@
+/*
+ *  Copyright © 2022.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.resource;
+
+import ai.asserts.aws.ObjectMapperFactory;
+import ai.asserts.aws.cloudwatch.alarms.FirehoseEventRequest;
+import ai.asserts.aws.cloudwatch.alarms.RecordData;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfig;
+import ai.asserts.aws.cloudwatch.config.ScrapeConfigProvider;
+import ai.asserts.aws.exporter.BasicMetricCollector;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.easymock.EasyMock.expect;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ResourceConfigControllerTest extends EasyMockSupport {
+
+    private ObjectMapperFactory objectMapperFactory;
+    private BasicMetricCollector metricCollector;
+    private ResourceMapper resourceMapper;
+    private ScrapeConfigProvider scrapeConfigProvider;
+    private ObjectMapper objectMapper;
+    private ScrapeConfig scrapeConfig;
+    private RecordData recordData;
+    private ResourceConfigController testClass;
+    private FirehoseEventRequest resourceConfig;
+    private ResourceConfigChange configChange;
+    private ResourceConfigChangeDetail changeDetail;
+    private ResourceConfigDiff configDiff;
+    private ResourceConfigItem configItem;
+    private Instant now;
+
+    @BeforeEach
+    public void setup() {
+        objectMapperFactory = mock(ObjectMapperFactory.class);
+        metricCollector = mock(BasicMetricCollector.class);
+        resourceMapper = mock(ResourceMapper.class);
+        scrapeConfigProvider = mock(ScrapeConfigProvider.class);
+        objectMapper = mock(ObjectMapper.class);
+        scrapeConfig = mock(ScrapeConfig.class);
+        resourceConfig = mock(FirehoseEventRequest.class);
+        recordData = mock(RecordData.class);
+        configChange = mock(ResourceConfigChange.class);
+        changeDetail = mock(ResourceConfigChangeDetail.class);
+        configDiff = mock(ResourceConfigDiff.class);
+        configItem = mock(ResourceConfigItem.class);
+        now = Instant.now();
+        testClass = new ResourceConfigController(objectMapperFactory, metricCollector, resourceMapper, scrapeConfigProvider) {
+            @Override
+            Instant now() {
+                return now;
+            }
+        };
+        expect(objectMapperFactory.getObjectMapper()).andReturn(objectMapper);
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(resourceConfig.getRecords()).andReturn(ImmutableList.of(recordData)).times(2);
+        expect(configChange.getDetail()).andReturn(changeDetail).anyTimes();
+        expect(changeDetail.getConfigurationItemDiff()).andReturn(configDiff).times(3);
+        expect(changeDetail.getConfigurationItem()).andReturn(configItem).times(3);
+    }
+
+    @Test
+    public void resourceConfigChangePost() throws JsonProcessingException {
+        Resource resource = mock(Resource.class);
+        expect(scrapeConfig.getDiscoverResourceTypes()).andReturn(ImmutableSet.of("AWS::EC2::Instance"));
+        expect(recordData.getData()).andReturn(Base64.getEncoder().encodeToString("test".getBytes()));
+        expect(objectMapper.readValue("test", ResourceConfigChange.class)).andReturn(configChange);
+        expect(configDiff.getChangeType()).andReturn("UPDATE").times(3);
+        expect(configItem.getResourceType()).andReturn("AWS::EC2::Instance").times(2);
+        expect(configItem.getResourceId()).andReturn("i-04ac60054729e1e1f");
+        expect(configChange.getRegion()).andReturn("r1");
+        expect(configChange.getAccount()).andReturn("123");
+        expect(configChange.getTime()).andReturn(now.minusSeconds(5).toString());
+        expect(configChange.getResources()).
+                andReturn(ImmutableList.of("arn:aws:ec2:us-west-2:342994379019:instance/i-04ac60054729e1e1f")).times(3);
+        expect(resourceMapper.map("arn:aws:ec2:us-west-2:342994379019:instance/i-04ac60054729e1e1f")).
+                andReturn(Optional.of(resource));
+        expect(resource.getName()).andReturn("i-04ac60054729e1e1f");
+        expect(resource.getType()).andReturn(ResourceType.EC2Instance);
+        SortedMap<String, String> labels = new TreeMap<>();
+        labels.put("account_id", "123");
+        labels.put("alertname", "Config-UPDATE");
+        labels.put("asserts_entity_type", "Service");
+        labels.put("job", "i-04ac60054729e1e1f");
+        labels.put("namespace", "AWS/EC2");
+        labels.put("region", "r1");
+        SortedMap<String, String> histoLabels = new TreeMap<>();
+        histoLabels.put("alertname", "Config-UPDATE");
+        histoLabels.put("job", "i-04ac60054729e1e1f");
+        histoLabels.put("namespace", "AWS/EC2");
+        histoLabels.put("region", "r1");
+        metricCollector.recordGaugeValue("aws_resource_config", labels, 1.0D);
+        metricCollector.recordHistogram("aws_exporter_delay_seconds", histoLabels, 5);
+        replayAll();
+        assertEquals(HttpStatus.OK, testClass.resourceConfigChangePost(resourceConfig).getStatusCode());
+        verifyAll();
+    }
+}


### PR DESCRIPTION
For configured resources in aws exporter if there is any change in configuration it will be pushed to aws exporter through Kinesis stream.
Process these events and convert to metric if the resource type is in the list of resource types configured and change type is not create. We discovered new resources create using a different path.
[ch11385]