### PR TITLE
Support for multiple assumeRole

### DIFF
--- a/src/main/java/ai/asserts/aws/AWSClientProvider.java
+++ b/src/main/java/ai/asserts/aws/AWSClientProvider.java
@@ -36,193 +36,193 @@ public class AWSClientProvider {
 
     public SecretsManagerClient getSecretsManagerClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return sessionConfig.map(config ->
-                SecretsManagerClient.builder()
-                        .credentialsProvider(() -> AwsSessionCredentials.create(
-                                config.getAccessKeyId(), config.getSecretAccessKey(),
-                                config.getSessionToken()))
-                        .region(Region.of(region)).build())
-                .orElse(SecretsManagerClient.builder().region(Region.of(region)).build());
-    }
-
-    public AutoScalingClient getAutoScalingClient(String region) {
-        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
-        return
-                sessionConfig.map(config ->
-                        AutoScalingClient.builder()
+                        SecretsManagerClient.builder()
                                 .credentialsProvider(() -> AwsSessionCredentials.create(
                                         config.getAccessKeyId(), config.getSecretAccessKey(),
                                         config.getSessionToken()))
                                 .region(Region.of(region)).build())
+                .orElse(SecretsManagerClient.builder().region(Region.of(region)).build());
+    }
+
+    public AutoScalingClient getAutoScalingClient(String region, String assumeRole) {
+        Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
+                assumeRole);
+        return
+                sessionConfig.map(config ->
+                                AutoScalingClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(AutoScalingClient.builder().region(Region.of(region)).build());
     }
 
     public ApiGatewayClient getApiGatewayClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        ApiGatewayClient.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build())
+                                ApiGatewayClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(ApiGatewayClient.builder().region(Region.of(region)).build());
     }
 
     public ElasticLoadBalancingV2Client getELBV2Client(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        ElasticLoadBalancingV2Client.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build())
+                                ElasticLoadBalancingV2Client.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(ElasticLoadBalancingV2Client.builder().region(Region.of(region)).build());
     }
 
     public ElasticLoadBalancingClient getELBClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config -> ElasticLoadBalancingClient.builder()
-                        .credentialsProvider(() -> AwsSessionCredentials.create(
-                                config.getAccessKeyId(), config.getSecretAccessKey(),
-                                config.getSessionToken()))
-                        .region(Region.of(region)).build())
+                                .credentialsProvider(() -> AwsSessionCredentials.create(
+                                        config.getAccessKeyId(), config.getSecretAccessKey(),
+                                        config.getSessionToken()))
+                                .region(Region.of(region)).build())
                         .orElse(ElasticLoadBalancingClient.builder().region(Region.of(region)).build());
     }
 
     public CloudWatchClient getCloudWatchClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        CloudWatchClient.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build())
+                                CloudWatchClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(CloudWatchClient.builder().region(Region.of(region)).build());
     }
 
     public CloudWatchLogsClient getCloudWatchLogsClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        CloudWatchLogsClient.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build())
+                                CloudWatchLogsClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(CloudWatchLogsClient.builder().region(Region.of(region)).build());
     }
 
     public LambdaClient getLambdaClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        LambdaClient.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build())
+                                LambdaClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(LambdaClient.builder().region(Region.of(region)).build());
     }
 
     public ResourceGroupsTaggingApiClient getResourceTagClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        ResourceGroupsTaggingApiClient.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build())
+                                ResourceGroupsTaggingApiClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(ResourceGroupsTaggingApiClient.builder().region(Region.of(region)).build());
     }
 
     public EcsClient getECSClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        EcsClient.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build())
+                                EcsClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(EcsClient.builder().region(Region.of(region)).build());
     }
 
     public ConfigClient getConfigClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return sessionConfig.map(config -> ConfigClient.builder()
-                .credentialsProvider(() -> AwsSessionCredentials.create(
-                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                        config.getSessionToken()))
-                .region(Region.of(region)).build())
+                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                config.getSessionToken()))
+                        .region(Region.of(region)).build())
                 .orElse(ConfigClient.builder().region(Region.of(region)).build());
     }
 
     public StsClient getStsClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        StsClient.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build())
+                                StsClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(StsClient.builder().region(Region.of(region)).build());
     }
 
     public Ec2Client getEc2Client(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        Ec2Client.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build())
+                                Ec2Client.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(Ec2Client.builder().region(Region.of(region)).build());
     }
 
     public KinesisAnalyticsV2Client getKAClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        KinesisAnalyticsV2Client.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build())
+                                KinesisAnalyticsV2Client.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build())
                         .orElse(KinesisAnalyticsV2Client.builder().region(Region.of(region)).build());
     }
 
     public FirehoseClient getFirehoseClient(String region) {
         Optional<AWSSessionConfig> sessionConfig = awsSessionProvider.getSessionCredential(region,
-                scrapeConfigProvider.getScrapeConfig().getAssumeRole());
+                scrapeConfigProvider.getScrapeConfig().getAssumeRoles().get(0));
         return
                 sessionConfig.map(config ->
-                        FirehoseClient.builder()
-                                .credentialsProvider(() -> AwsSessionCredentials.create(
-                                        config.getAccessKeyId(), config.getSecretAccessKey(),
-                                        config.getSessionToken()))
-                                .region(Region.of(region)).build()
-                )
+                                FirehoseClient.builder()
+                                        .credentialsProvider(() -> AwsSessionCredentials.create(
+                                                config.getAccessKeyId(), config.getSecretAccessKey(),
+                                                config.getSessionToken()))
+                                        .region(Region.of(region)).build()
+                        )
                         .orElse(FirehoseClient.builder().region(Region.of(region)).build());
     }
 }

--- a/src/main/java/ai/asserts/aws/AWSSessionProvider.java
+++ b/src/main/java/ai/asserts/aws/AWSSessionProvider.java
@@ -6,49 +6,56 @@ package ai.asserts.aws;
 
 import ai.asserts.aws.cloudwatch.TimeWindowBuilder;
 import org.springframework.stereotype.Component;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 
-import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Component
 public class AWSSessionProvider {
     private final TimeWindowBuilder timeWindowBuilder;
-    private final AtomicReference<AWSSessionConfig> currentSession;
+    private final AtomicReference<Map<String, AWSSessionConfig>> currentSession;
 
     public AWSSessionProvider(TimeWindowBuilder timeWindowBuilder) {
         this.timeWindowBuilder = timeWindowBuilder;
         currentSession = new AtomicReference<>();
-        currentSession.set(null);
+        currentSession.set(new HashMap<>());
     }
 
     public Optional<AWSSessionConfig> getSessionCredential(String region, String assumeRole) {
         if (assumeRole != null) {
-            if (currentSession.get() != null &&
+            if (currentSession.get().get(assumeRole) != null &&
                     timeWindowBuilder.getZonedDateTime(region).toInstant().
-                            compareTo(currentSession.get().getExpiring()) < 0) {
-                return Optional.of(currentSession.get());
+                            compareTo(currentSession.get().get(assumeRole).getExpiring()) < 0) {
+                return Optional.of(currentSession.get().get(assumeRole));
             }
             StsClient stsClient = StsClient.builder().region(Region.of(region))
+                    .credentialsProvider(StaticCredentialsProvider
+                            .create(AwsBasicCredentials.create("AKIAU7XAO4EFTCSBSJKT", "iRMBUlkw1YQxxsFW+8onon+F/qtNITw9zGeJFHDe")))
                     .build();
             AssumeRoleResponse response = stsClient.assumeRole(AssumeRoleRequest.builder()
                     .roleSessionName("session1")
                     .roleArn(assumeRole)
                     .build());
             if (response.credentials() != null) {
-                AWSSessionConfig preValue = currentSession.get();
-                AWSSessionConfig newValue = AWSSessionConfig.builder()
+                Map<String, AWSSessionConfig> preValue = currentSession.get();
+                AWSSessionConfig newConfig = AWSSessionConfig.builder()
                         .accessKeyId(response.credentials().accessKeyId())
                         .secretAccessKey(response.credentials().secretAccessKey())
                         .sessionToken(response.credentials().sessionToken())
                         .expiring(response.credentials().expiration())
                         .build();
+                Map<String, AWSSessionConfig> newValue = new HashMap<>(preValue);
+                newValue.put(assumeRole, newConfig);
                 currentSession.compareAndSet(preValue, newValue);
-                return Optional.of(currentSession.get());
+                return Optional.of(currentSession.get().get(assumeRole));
             }
         }
         return Optional.empty();

--- a/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfig.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/config/ScrapeConfig.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.ecs.model.TaskDefinition;
 import software.amazon.awssdk.services.resourcegroupstaggingapi.model.Tag;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -90,7 +91,8 @@ public class ScrapeConfig {
 
     private String tenant;
 
-    private String assumeRole;
+    @Builder.Default
+    private List<String> assumeRole = new ArrayList<>();
 
     @Builder.Default
     private List<RelabelConfig> relabelConfigs = new ArrayList<>();
@@ -160,9 +162,9 @@ public class ScrapeConfig {
             dimensionToLabels.stream()
                     .filter(d -> alarmDimensions.containsKey(d.getDimensionName()))
                     .findFirst().ifPresent(dimensionToLabel -> {
-                mapTypeAndName(alarmDimensions, labels, dimensionToLabel);
-                labels.put("namespace", dimensionToLabel.getNamespace());
-            });
+                        mapTypeAndName(alarmDimensions, labels, dimensionToLabel);
+                        labels.put("namespace", dimensionToLabel.getNamespace());
+                    });
         }
 
         return labels;
@@ -210,6 +212,13 @@ public class ScrapeConfig {
             labels = config.addReplacements(metricName, labels);
         }
         return labels;
+    }
+
+    public List<String> getAssumeRoles() {
+        if (CollectionUtils.isEmpty(assumeRole)) {
+            return Collections.singletonList(null); //null when no assume role is configured.
+        }
+        return assumeRole;
     }
 }
 

--- a/src/main/java/ai/asserts/aws/exporter/AccountIDProvider.java
+++ b/src/main/java/ai/asserts/aws/exporter/AccountIDProvider.java
@@ -12,12 +12,15 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.sts.StsClient;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 @Component
 @Slf4j
 public class AccountIDProvider implements InitializingBean {
+    public static final Pattern ROLE_PATTERN = Pattern.compile("arn:aws:iam::(.+?):role/(.+)");
     private final AWSClientProvider awsClientProvider;
     private final ScrapeConfigProvider scrapeConfigProvider;
-
     @Getter
     private String accountId;
 
@@ -33,5 +36,16 @@ public class AccountIDProvider implements InitializingBean {
             StsClient stsClient = awsClientProvider.getStsClient(anyRegion);
             accountId = stsClient.getCallerIdentity().account();
         }
+    }
+
+    public String getRoleAccountID(String role) {
+        if (role != null) {
+            Matcher matcher = ROLE_PATTERN.matcher(role);
+            if (matcher.matches()) {
+                return matcher.group(1);
+            }
+            return "";
+        }
+        return accountId;
     }
 }

--- a/src/test/java/ai/asserts/aws/exporter/AccountIDProviderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/AccountIDProviderTest.java
@@ -46,4 +46,20 @@ public class AccountIDProviderTest extends EasyMockSupport {
         assertEquals("TestAccount", testClass.getAccountId());
         verifyAll();
     }
+
+    @Test
+    public void getRoleAccountID() {
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
+        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region")).anyTimes();
+        expect(awsClientProvider.getStsClient("region")).andReturn(stsClient);
+        expect(stsClient.getCallerIdentity()).andReturn(GetCallerIdentityResponse.builder()
+                .account("TestAccount")
+                .build());
+        replayAll();
+        testClass.afterPropertiesSet();
+        assertEquals("TestAccount", testClass.getRoleAccountID(null));
+        assertEquals("342994379019", testClass.
+                getRoleAccountID("arn:aws:iam::342994379019:role/grafana-cloudwatch-assumerole"));
+        verifyAll();
+    }
 }

--- a/src/test/java/ai/asserts/aws/exporter/LBToASGRelationBuilderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/LBToASGRelationBuilderTest.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.services.autoscaling.AutoScalingClient;
 import software.amazon.awssdk.services.autoscaling.model.AutoScalingGroup;
 import software.amazon.awssdk.services.autoscaling.model.DescribeAutoScalingGroupsResponse;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.SortedMap;
 
@@ -58,11 +59,12 @@ public class LBToASGRelationBuilderTest extends EasyMockSupport {
 
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
         expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region"));
+        expect(scrapeConfig.getAssumeRoles()).andReturn(Collections.singletonList(null));
     }
 
     @Test
     void updateRouting() {
-        expect(awsClientProvider.getAutoScalingClient("region")).andReturn(autoScalingClient);
+        expect(awsClientProvider.getAutoScalingClient("region", null)).andReturn(autoScalingClient);
         expect(autoScalingClient.describeAutoScalingGroups()).andReturn(DescribeAutoScalingGroupsResponse.builder()
                 .autoScalingGroups(AutoScalingGroup.builder()
                         .autoScalingGroupARN("asg-arn")


### PR DESCRIPTION
Assume role can be multiple when customer has multiple aws account and wants to run single aws-exporter to get all information.
The change in this PR is for one of the aws client provider and i will have following PRs for different aws clients.
[ch11754]