### PR TITLE
Scrape all ECS tasks by default

### DIFF
--- a/config/src/test/java/ai/asserts/aws/config/ScrapeConfigTest.java
+++ b/config/src/test/java/ai/asserts/aws/config/ScrapeConfigTest.java
@@ -128,4 +128,28 @@ public class ScrapeConfigTest extends EasyMockSupport {
         ), finalLabels);
         verifyAll();
     }
+
+    @Test
+    void getECSScrapeConfigByNameAndPort() {
+        ECSTaskDefScrapeConfig withoutPort = new ECSTaskDefScrapeConfig()
+                .withContainerDefinitionName("container")
+                .withMetricPath("/metric/path");
+        ECSTaskDefScrapeConfig withPort = new ECSTaskDefScrapeConfig()
+                .withContainerDefinitionName("container")
+                .withContainerPort(8080)
+                .withMetricPath("/metric/path1");
+
+        ScrapeConfig scrapeConfig = ScrapeConfig.builder()
+                .ecsTaskScrapeConfigs(ImmutableList.of(withoutPort, withPort))
+                .build();
+
+        replayAll();
+        assertEquals(ImmutableMap.of(
+                "container", ImmutableMap.of(
+                        -1, withoutPort,
+                        8080, withPort
+                )
+        ), scrapeConfig.getECSConfigByNameAndPort());
+        verifyAll();
+    }
 }

--- a/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
@@ -7,8 +7,8 @@ package ai.asserts.aws.exporter;
 import ai.asserts.aws.AWSClientProvider;
 import ai.asserts.aws.ObjectMapperFactory;
 import ai.asserts.aws.RateLimiter;
-import ai.asserts.aws.config.ScrapeConfig;
 import ai.asserts.aws.ScrapeConfigProvider;
+import ai.asserts.aws.config.ScrapeConfig;
 import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
 import ai.asserts.aws.resource.Resource;
 import ai.asserts.aws.resource.ResourceMapper;
@@ -372,11 +372,11 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
         expect(ecsTaskUtil.hasAllInfo(task1)).andReturn(true);
         expect(ecsTaskUtil.hasAllInfo(task2)).andReturn(true);
 
-        expect(ecsTaskUtil.buildScrapeTarget(scrapeConfig, ecsClient, cluster, service, task1))
-                .andReturn(Optional.of(mockStaticConfig));
+        expect(ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster, service, task1))
+                .andReturn(ImmutableList.of(mockStaticConfig));
 
-        expect(ecsTaskUtil.buildScrapeTarget(scrapeConfig, ecsClient, cluster, service, task2))
-                .andReturn(Optional.of(mockStaticConfig));
+        expect(ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster, service, task2))
+                .andReturn(ImmutableList.of(mockStaticConfig));
 
         replayAll();
         ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(scrapeConfigProvider, awsClientProvider,

--- a/src/test/java/ai/asserts/aws/exporter/ECSTaskUtilTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSTaskUtilTest.java
@@ -10,7 +10,6 @@ import ai.asserts.aws.config.ScrapeConfig;
 import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
 import ai.asserts.aws.resource.Resource;
 import ai.asserts.aws.resource.ResourceMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.easymock.EasyMockSupport;
@@ -26,10 +25,9 @@ import software.amazon.awssdk.services.ecs.model.PortMapping;
 import software.amazon.awssdk.services.ecs.model.Task;
 import software.amazon.awssdk.services.ecs.model.TaskDefinition;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.SortedMap;
 
-import static ai.asserts.aws.MetricNameUtil.SCRAPE_ERROR_COUNT_METRIC;
 import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
 import static ai.asserts.aws.exporter.ECSTaskUtil.ENI;
 import static ai.asserts.aws.exporter.ECSTaskUtil.PRIVATE_IPv4ADDRESS;
@@ -108,173 +106,21 @@ public class ECSTaskUtilTest extends EasyMockSupport {
     }
 
     @Test
-    public void getECSScrapeConfig_None() {
-        ScrapeConfig scrapeConfig = ScrapeConfig.builder().build();
-        assertEquals(Optional.empty(), testClass.getECSScrapeConfig(TaskDefinition.builder().build(), scrapeConfig));
-    }
-
-    @Test
-    public void getECSScrapeConfig_Exists() {
-        ECSTaskDefScrapeConfig mockConfig = mock(ECSTaskDefScrapeConfig.class);
-        ScrapeConfig scrapeConfig = ScrapeConfig.builder()
-                .ecsTaskScrapeConfigs(ImmutableList.of(mockConfig))
-                .build();
-        TaskDefinition taskDefinition = TaskDefinition.builder()
-                .containerDefinitions(ContainerDefinition.builder().name("cn").build())
-                .build();
-
-        expect(mockConfig.getContainerDefinitionName()).andReturn("cn");
-
-        replayAll();
-        assertEquals(Optional.of(mockConfig), testClass.getECSScrapeConfig(taskDefinition, scrapeConfig));
-        verifyAll();
-    }
-
-    @Test
-    public void buildScrapeTarget_use_taskdef_docker_labels_config_success() {
+    public void containerWithDockerLabels() {
         expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
         expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
-        expect(scrapeConfig.getEcsTaskScrapeConfigs()).andReturn(ImmutableList.of()).anyTimes();
-
-        TaskDefinition taskDefinition = TaskDefinition.builder()
-                .containerDefinitions(ContainerDefinition.builder()
-                                .name("model-builder")
-                                .portMappings(PortMapping.builder()
-                                        .containerPort(8080)
-                                        .hostPort(53234)
-                                        .build())
-                                .dockerLabels(ImmutableMap.of(
-                                        PROMETHEUS_METRIC_PATH_DOCKER_LABEL, "/metric/path",
-                                        PROMETHEUS_PORT_DOCKER_LABEL, "8080"
-                                ))
-                                .build(),
-                        ContainerDefinition.builder()
-                                .name("sidecar")
-                                .portMappings(PortMapping.builder()
-                                        .containerPort(8081)
-                                        .hostPort(53235)
-                                        .build())
-                                .build())
-                .build();
-
-        expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
-                .taskDefinition("task-def-arn")
-                .build())).andReturn(DescribeTaskDefinitionResponse.builder()
-                .taskDefinition(taskDefinition)
-                .build());
-        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
-
-        replayAll();
-        Optional<StaticConfig> staticConfigOpt = testClass.buildScrapeTarget(scrapeConfig, ecsClient, cluster,
-                service, Task.builder()
-                        .taskArn("task-arn")
-                        .taskDefinitionArn("task-def-arn")
-                        .lastStatus("RUNNING")
-                        .attachments(Attachment.builder()
-                                .type(ENI)
-                                .details(KeyValuePair.builder()
-                                        .name(PRIVATE_IPv4ADDRESS)
-                                        .value("10.20.30.40")
-                                        .build())
-                                .build())
-                        .build());
-        assertTrue(staticConfigOpt.isPresent());
-        StaticConfig staticConfig = staticConfigOpt.get();
-        assertAll(
-                () -> assertEquals("cluster", staticConfig.getLabels().getCluster()),
-                () -> assertEquals("service", staticConfig.getLabels().getJob()),
-                () -> assertEquals("task-def", staticConfig.getLabels().getTaskDefName()),
-                () -> assertEquals("5", staticConfig.getLabels().getTaskDefVersion()),
-                () -> assertEquals("task-id", staticConfig.getLabels().getTaskId()),
-                () -> assertEquals("/metric/path", staticConfig.getLabels().getMetricsPath()),
-                () -> assertEquals(ImmutableSet.of("10.20.30.40:53234"), staticConfig.getTargets())
-        );
-        verifyAll();
-    }
-
-    @Test
-    public void buildScrapeTarget_use_taskdef_config_success() {
-        expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
-        expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
-
-        expect(scrapeConfig.getEcsTaskScrapeConfigs()).andReturn(ImmutableList.of(taskDefScrapeConfig)).anyTimes();
-
-        expect(taskDefScrapeConfig.getContainerDefinitionName()).andReturn("model-builder").anyTimes();
-        expect(taskDefScrapeConfig.getMetricPath()).andReturn("/metric/path").anyTimes();
-        expect(taskDefScrapeConfig.getContainerPort()).andReturn(8080).anyTimes();
-
-        TaskDefinition taskDefinition = TaskDefinition.builder()
-                .containerDefinitions(ContainerDefinition.builder()
-                                .name("model-builder")
-                                .portMappings(PortMapping.builder()
-                                        .containerPort(8080)
-                                        .hostPort(53234)
-                                        .build())
-                                .build(),
-                        ContainerDefinition.builder()
-                                .name("sidecar")
-                                .portMappings(PortMapping.builder()
-                                        .containerPort(8081)
-                                        .hostPort(53235)
-                                        .build())
-                                .build())
-                .build();
-        expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
-                .taskDefinition("task-def-arn")
-                .build())).andReturn(DescribeTaskDefinitionResponse.builder()
-                .taskDefinition(taskDefinition)
-                .build());
-
-        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
-
-        replayAll();
-        Optional<StaticConfig> staticConfigOpt = testClass.buildScrapeTarget(scrapeConfig, ecsClient, cluster,
-                service, Task.builder()
-                        .taskArn("task-arn")
-                        .taskDefinitionArn("task-def-arn")
-                        .lastStatus("RUNNING")
-                        .attachments(Attachment.builder()
-                                .type(ENI)
-                                .details(KeyValuePair.builder()
-                                        .name(PRIVATE_IPv4ADDRESS)
-                                        .value("10.20.30.40")
-                                        .build())
-                                .build())
-                        .build());
-        assertTrue(staticConfigOpt.isPresent());
-        StaticConfig staticConfig = staticConfigOpt.get();
-        assertAll(
-                () -> assertEquals("cluster", staticConfig.getLabels().getCluster()),
-                () -> assertEquals("service", staticConfig.getLabels().getJob()),
-                () -> assertEquals("task-def", staticConfig.getLabels().getTaskDefName()),
-                () -> assertEquals("5", staticConfig.getLabels().getTaskDefVersion()),
-                () -> assertEquals("task-id", staticConfig.getLabels().getTaskId()),
-                () -> assertEquals("/metric/path", staticConfig.getLabels().getMetricsPath()),
-                () -> assertEquals(ImmutableSet.of("10.20.30.40:53234"), staticConfig.getTargets())
-        );
-        verifyAll();
-    }
-
-    @Test
-    public void buildScrapeTarget_without_taskdef_config_success() {
-        expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
-        expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
-
-        expect(scrapeConfig.getEcsTaskScrapeConfigs()).andReturn(ImmutableList.of(taskDefScrapeConfig)).anyTimes();
-
-        expect(taskDefScrapeConfig.getContainerDefinitionName()).andReturn("model-builder-v1").anyTimes();
-        expect(taskDefScrapeConfig.getMetricPath()).andReturn("/metric/path").anyTimes();
-        expect(taskDefScrapeConfig.getContainerPort()).andReturn(8080).anyTimes();
+        expect(scrapeConfig.getECSConfigByNameAndPort()).andReturn(ImmutableMap.of());
 
         TaskDefinition taskDefinition = TaskDefinition.builder()
                 .containerDefinitions(ContainerDefinition.builder()
                         .name("model-builder")
-                        .portMappings(PortMapping.builder()
-                                .containerPort(8080)
-                                .hostPort(53234)
-                                .build())
+                        .dockerLabels(ImmutableMap.of(
+                                PROMETHEUS_METRIC_PATH_DOCKER_LABEL, "/metric/path",
+                                PROMETHEUS_PORT_DOCKER_LABEL, "8080"
+                        ))
                         .build())
                 .build();
+
         expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
                 .taskDefinition("task-def-arn")
                 .build())).andReturn(DescribeTaskDefinitionResponse.builder()
@@ -283,7 +129,7 @@ public class ECSTaskUtilTest extends EasyMockSupport {
         metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
 
         replayAll();
-        Optional<StaticConfig> staticConfigOpt = testClass.buildScrapeTarget(scrapeConfig, ecsClient, cluster,
+        List<StaticConfig> staticConfigs = testClass.buildScrapeTargets(scrapeConfig, ecsClient, cluster,
                 service, Task.builder()
                         .taskArn("task-arn")
                         .taskDefinitionArn("task-def-arn")
@@ -296,33 +142,53 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                                         .build())
                                 .build())
                         .build());
-        assertFalse(staticConfigOpt.isPresent());
+        assertEquals(1, staticConfigs.size());
+        StaticConfig staticConfig = staticConfigs.get(0);
+        assertAll(
+                () -> assertEquals("cluster", staticConfig.getLabels().getCluster()),
+                () -> assertEquals("service", staticConfig.getLabels().getJob()),
+                () -> assertEquals("task-def", staticConfig.getLabels().getTaskDefName()),
+                () -> assertEquals("5", staticConfig.getLabels().getTaskDefVersion()),
+                () -> assertEquals("task-id", staticConfig.getLabels().getTaskId()),
+                () -> assertEquals("/metric/path", staticConfig.getLabels().getMetricsPath()),
+                () -> assertEquals("model-builder", staticConfig.getLabels().getContainer()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:8080"), staticConfig.getTargets())
+        );
         verifyAll();
     }
 
     @Test
-    public void buildScrapeTarget_without_taskdef_config_no_result() {
+    public void discoverAllTasksNoConfig() {
         expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
         expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
+        expect(scrapeConfig.isDiscoverAllECSTasksByDefault()).andReturn(true).anyTimes();
+        expect(scrapeConfig.getECSConfigByNameAndPort()).andReturn(ImmutableMap.of());
 
-        expect(scrapeConfig.getEcsTaskScrapeConfigs()).andReturn(ImmutableList.of()).anyTimes();
+        expect(taskDefScrapeConfig.getMetricPath()).andReturn("/prometheus/metrics").anyTimes();
 
         TaskDefinition taskDefinition = TaskDefinition.builder()
-                .containerDefinitions(ContainerDefinition.builder()
+                .containerDefinitions(
+                        ContainerDefinition.builder()
                                 .name("model-builder")
                                 .portMappings(PortMapping.builder()
+                                        .hostPort(52341)
                                         .containerPort(8080)
-                                        .hostPort(53234)
                                         .build())
                                 .build(),
                         ContainerDefinition.builder()
-                                .name("sidecar")
-                                .portMappings(PortMapping.builder()
-                                        .containerPort(8081)
-                                        .hostPort(53235)
-                                        .build())
-                                .build())
-                .build();
+                                .name("api-server")
+                                .portMappings(
+                                        PortMapping.builder()
+                                                .hostPort(52342)
+                                                .containerPort(8081)
+                                                .build(),
+                                        PortMapping.builder()
+                                                .hostPort(52343)
+                                                .containerPort(8082)
+                                                .build()
+                                ).build()
+                ).build();
+
         expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
                 .taskDefinition("task-def-arn")
                 .build())).andReturn(DescribeTaskDefinitionResponse.builder()
@@ -331,7 +197,7 @@ public class ECSTaskUtilTest extends EasyMockSupport {
         metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
 
         replayAll();
-        Optional<StaticConfig> staticConfigOpt = testClass.buildScrapeTarget(scrapeConfig, ecsClient, cluster,
+        List<StaticConfig> staticConfigs = testClass.buildScrapeTargets(scrapeConfig, ecsClient, cluster,
                 service, Task.builder()
                         .taskArn("task-arn")
                         .taskDefinitionArn("task-def-arn")
@@ -344,23 +210,74 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                                         .build())
                                 .build())
                         .build());
-        assertFalse(staticConfigOpt.isPresent());
+        assertEquals(2, staticConfigs.size());
+        assertAll(
+                () -> assertEquals("cluster", staticConfigs.get(0).getLabels().getCluster()),
+                () -> assertEquals("service", staticConfigs.get(0).getLabels().getJob()),
+                () -> assertEquals("task-def", staticConfigs.get(0).getLabels().getTaskDefName()),
+                () -> assertEquals("5", staticConfigs.get(0).getLabels().getTaskDefVersion()),
+                () -> assertEquals("task-id", staticConfigs.get(0).getLabels().getTaskId()),
+                () -> assertEquals("/metrics", staticConfigs.get(0).getLabels().getMetricsPath()),
+                () -> assertEquals("api-server", staticConfigs.get(0).getLabels().getContainer()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:8081", "10.20.30.40:8082"),
+                        staticConfigs.get(0).getTargets())
+        );
+        assertAll(
+                () -> assertEquals("cluster", staticConfigs.get(1).getLabels().getCluster()),
+                () -> assertEquals("service", staticConfigs.get(1).getLabels().getJob()),
+                () -> assertEquals("task-def", staticConfigs.get(1).getLabels().getTaskDefName()),
+                () -> assertEquals("5", staticConfigs.get(1).getLabels().getTaskDefVersion()),
+                () -> assertEquals("task-id", staticConfigs.get(1).getLabels().getTaskId()),
+                () -> assertEquals("/metrics", staticConfigs.get(1).getLabels().getMetricsPath()),
+                () -> assertEquals("model-builder", staticConfigs.get(1).getLabels().getContainer()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:8080"), staticConfigs.get(1).getTargets())
+        );
         verifyAll();
     }
 
     @Test
-    public void buildScrapeTarget_use_taskdef_config_exception() {
+    public void discoverAllTasksSomeWithConfig() {
         expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
         expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
+        expect(scrapeConfig.isDiscoverAllECSTasksByDefault()).andReturn(true).anyTimes();
+        expect(scrapeConfig.getECSConfigByNameAndPort()).andReturn(
+                ImmutableMap.of("api-server",
+                        ImmutableMap.of(-1, taskDefScrapeConfig)));
+
+        expect(taskDefScrapeConfig.getMetricPath()).andReturn("/prometheus/metrics").anyTimes();
+
+        TaskDefinition taskDefinition = TaskDefinition.builder()
+                .containerDefinitions(
+                        ContainerDefinition.builder()
+                                .name("model-builder")
+                                .portMappings(PortMapping.builder()
+                                        .hostPort(52341)
+                                        .containerPort(8080)
+                                        .build())
+                                .build(),
+                        ContainerDefinition.builder()
+                                .name("api-server")
+                                .portMappings(
+                                        PortMapping.builder()
+                                                .hostPort(52342)
+                                                .containerPort(8081)
+                                                .build(),
+                                        PortMapping.builder()
+                                                .hostPort(52343)
+                                                .containerPort(8082)
+                                                .build()
+                                ).build()
+                ).build();
 
         expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
                 .taskDefinition("task-def-arn")
-                .build())).andThrow(new RuntimeException());
-        metricCollector.recordCounterValue(eq(SCRAPE_ERROR_COUNT_METRIC), anyObject(SortedMap.class), eq(1));
-        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(SortedMap.class), anyLong());
+                .build())).andReturn(DescribeTaskDefinitionResponse.builder()
+                .taskDefinition(taskDefinition)
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
 
         replayAll();
-        Optional<StaticConfig> staticConfigOpt = testClass.buildScrapeTarget(scrapeConfig, ecsClient, cluster,
+        List<StaticConfig> staticConfigs = testClass.buildScrapeTargets(scrapeConfig, ecsClient, cluster,
                 service, Task.builder()
                         .taskArn("task-arn")
                         .taskDefinitionArn("task-def-arn")
@@ -373,7 +290,189 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                                         .build())
                                 .build())
                         .build());
-        assertFalse(staticConfigOpt.isPresent());
+        assertEquals(2, staticConfigs.size());
+        assertAll(
+                () -> assertEquals("cluster", staticConfigs.get(0).getLabels().getCluster()),
+                () -> assertEquals("service", staticConfigs.get(0).getLabels().getJob()),
+                () -> assertEquals("task-def", staticConfigs.get(0).getLabels().getTaskDefName()),
+                () -> assertEquals("5", staticConfigs.get(0).getLabels().getTaskDefVersion()),
+                () -> assertEquals("task-id", staticConfigs.get(0).getLabels().getTaskId()),
+                () -> assertEquals("/prometheus/metrics", staticConfigs.get(0).getLabels().getMetricsPath()),
+                () -> assertEquals("api-server", staticConfigs.get(0).getLabels().getContainer()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:8081", "10.20.30.40:8082"),
+                        staticConfigs.get(0).getTargets())
+        );
+        assertAll(
+                () -> assertEquals("cluster", staticConfigs.get(1).getLabels().getCluster()),
+                () -> assertEquals("service", staticConfigs.get(1).getLabels().getJob()),
+                () -> assertEquals("task-def", staticConfigs.get(1).getLabels().getTaskDefName()),
+                () -> assertEquals("5", staticConfigs.get(1).getLabels().getTaskDefVersion()),
+                () -> assertEquals("task-id", staticConfigs.get(1).getLabels().getTaskId()),
+                () -> assertEquals("/metrics", staticConfigs.get(1).getLabels().getMetricsPath()),
+                () -> assertEquals("model-builder", staticConfigs.get(1).getLabels().getContainer()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:8080"), staticConfigs.get(1).getTargets())
+        );
         verifyAll();
     }
+
+    @Test
+    public void discoverAllTasksSpecificConfigForSpecificPorts() {
+        expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
+        expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
+        expect(scrapeConfig.isDiscoverAllECSTasksByDefault()).andReturn(true).anyTimes();
+        expect(scrapeConfig.getECSConfigByNameAndPort()).andReturn(
+                ImmutableMap.of("api-server",
+                        ImmutableMap.of(8081, taskDefScrapeConfig)));
+
+        expect(taskDefScrapeConfig.getMetricPath()).andReturn("/prometheus/metrics").anyTimes();
+
+        TaskDefinition taskDefinition = TaskDefinition.builder()
+                .containerDefinitions(
+                        ContainerDefinition.builder()
+                                .name("model-builder")
+                                .portMappings(PortMapping.builder()
+                                        .hostPort(52341)
+                                        .containerPort(8080)
+                                        .build())
+                                .build(),
+                        ContainerDefinition.builder()
+                                .name("api-server")
+                                .portMappings(
+                                        PortMapping.builder()
+                                                .hostPort(52342)
+                                                .containerPort(8081)
+                                                .build(),
+                                        PortMapping.builder()
+                                                .hostPort(52343)
+                                                .containerPort(8082)
+                                                .build()
+                                ).build()
+                ).build();
+
+        expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
+                .taskDefinition("task-def-arn")
+                .build())).andReturn(DescribeTaskDefinitionResponse.builder()
+                .taskDefinition(taskDefinition)
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+
+        replayAll();
+        List<StaticConfig> staticConfigs = testClass.buildScrapeTargets(scrapeConfig, ecsClient, cluster,
+                service, Task.builder()
+                        .taskArn("task-arn")
+                        .taskDefinitionArn("task-def-arn")
+                        .lastStatus("RUNNING")
+                        .attachments(Attachment.builder()
+                                .type(ENI)
+                                .details(KeyValuePair.builder()
+                                        .name(PRIVATE_IPv4ADDRESS)
+                                        .value("10.20.30.40")
+                                        .build())
+                                .build())
+                        .build());
+        assertEquals(3, staticConfigs.size());
+        assertAll(
+                () -> assertEquals("cluster", staticConfigs.get(0).getLabels().getCluster()),
+                () -> assertEquals("service", staticConfigs.get(0).getLabels().getJob()),
+                () -> assertEquals("task-def", staticConfigs.get(0).getLabels().getTaskDefName()),
+                () -> assertEquals("5", staticConfigs.get(0).getLabels().getTaskDefVersion()),
+                () -> assertEquals("task-id", staticConfigs.get(0).getLabels().getTaskId()),
+                () -> assertEquals("/prometheus/metrics", staticConfigs.get(0).getLabels().getMetricsPath()),
+                () -> assertEquals("api-server", staticConfigs.get(0).getLabels().getContainer()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:8081"),
+                        staticConfigs.get(0).getTargets())
+        );
+        assertAll(
+                () -> assertEquals("cluster", staticConfigs.get(1).getLabels().getCluster()),
+                () -> assertEquals("service", staticConfigs.get(1).getLabels().getJob()),
+                () -> assertEquals("task-def", staticConfigs.get(1).getLabels().getTaskDefName()),
+                () -> assertEquals("5", staticConfigs.get(1).getLabels().getTaskDefVersion()),
+                () -> assertEquals("task-id", staticConfigs.get(1).getLabels().getTaskId()),
+                () -> assertEquals("/metrics", staticConfigs.get(1).getLabels().getMetricsPath()),
+                () -> assertEquals("api-server", staticConfigs.get(1).getLabels().getContainer()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:8082"),
+                        staticConfigs.get(1).getTargets())
+        );
+        assertAll(
+                () -> assertEquals("cluster", staticConfigs.get(2).getLabels().getCluster()),
+                () -> assertEquals("service", staticConfigs.get(2).getLabels().getJob()),
+                () -> assertEquals("task-def", staticConfigs.get(2).getLabels().getTaskDefName()),
+                () -> assertEquals("5", staticConfigs.get(2).getLabels().getTaskDefVersion()),
+                () -> assertEquals("task-id", staticConfigs.get(2).getLabels().getTaskId()),
+                () -> assertEquals("/metrics", staticConfigs.get(2).getLabels().getMetricsPath()),
+                () -> assertEquals("model-builder", staticConfigs.get(2).getLabels().getContainer()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:8080"), staticConfigs.get(2).getTargets())
+        );
+        verifyAll();
+    }
+
+    @Test
+    public void discoverOnlyConfiguredTasks() {
+        expect(resourceMapper.map("task-def-arn")).andReturn(Optional.of(taskDef));
+        expect(resourceMapper.map("task-arn")).andReturn(Optional.of(task));
+        expect(scrapeConfig.isDiscoverAllECSTasksByDefault()).andReturn(false).anyTimes();
+        expect(scrapeConfig.getECSConfigByNameAndPort()).andReturn(
+                ImmutableMap.of("api-server", ImmutableMap.of(8081, taskDefScrapeConfig)));
+
+        expect(taskDefScrapeConfig.getMetricPath()).andReturn("/prometheus/metrics").anyTimes();
+
+        TaskDefinition taskDefinition = TaskDefinition.builder()
+                .containerDefinitions(
+                        ContainerDefinition.builder()
+                                .name("model-builder")
+                                .portMappings(PortMapping.builder()
+                                        .hostPort(52341)
+                                        .containerPort(8080)
+                                        .build())
+                                .build(),
+                        ContainerDefinition.builder()
+                                .name("api-server")
+                                .portMappings(
+                                        PortMapping.builder()
+                                                .hostPort(52342)
+                                                .containerPort(8081)
+                                                .build(),
+                                        PortMapping.builder()
+                                                .hostPort(52343)
+                                                .containerPort(8082)
+                                                .build()
+                                ).build()
+                ).build();
+
+        expect(ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
+                .taskDefinition("task-def-arn")
+                .build())).andReturn(DescribeTaskDefinitionResponse.builder()
+                .taskDefinition(taskDefinition)
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
+
+        replayAll();
+        List<StaticConfig> staticConfigs = testClass.buildScrapeTargets(scrapeConfig, ecsClient, cluster,
+                service, Task.builder()
+                        .taskArn("task-arn")
+                        .taskDefinitionArn("task-def-arn")
+                        .lastStatus("RUNNING")
+                        .attachments(Attachment.builder()
+                                .type(ENI)
+                                .details(KeyValuePair.builder()
+                                        .name(PRIVATE_IPv4ADDRESS)
+                                        .value("10.20.30.40")
+                                        .build())
+                                .build())
+                        .build());
+        assertEquals(1, staticConfigs.size());
+        assertAll(
+                () -> assertEquals("cluster", staticConfigs.get(0).getLabels().getCluster()),
+                () -> assertEquals("service", staticConfigs.get(0).getLabels().getJob()),
+                () -> assertEquals("task-def", staticConfigs.get(0).getLabels().getTaskDefName()),
+                () -> assertEquals("5", staticConfigs.get(0).getLabels().getTaskDefVersion()),
+                () -> assertEquals("task-id", staticConfigs.get(0).getLabels().getTaskId()),
+                () -> assertEquals("/prometheus/metrics", staticConfigs.get(0).getLabels().getMetricsPath()),
+                () -> assertEquals("api-server", staticConfigs.get(0).getLabels().getContainer()),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:8081"),
+                        staticConfigs.get(0).getTargets())
+        );
+        verifyAll();
+    }
+
 }


### PR DESCRIPTION
[ch11970]

Tetra science has lots of ECS tasks. Having to configure the metric path for each will be painful.

- If Prometheus export path and port are specified using Docker labels use that
- Scrape all ECS Tasks by default assuming the metric path is `/metrics`.
- Allow for scraping only configured container/ports
