### PR TITLE
Emit lambda resource metrics using direct API

### DIFF
--- a/src/dist/conf/cloudwatch_scrape_config_sample.yml
+++ b/src/dist/conf/cloudwatch_scrape_config_sample.yml
@@ -63,7 +63,6 @@ discoverResourceTypes:
   - AWS::ElasticLoadBalancing::LoadBalancer
   - AWS::AutoScaling::AutoScalingGroup
   - AWS::DynamoDB::Table
-  - AWS::Lambda::Function
   - AWS::ApiGateway::RestApi
   - AWS::ApiGatewayV2::Api
   - AWS::SQS::Queue
@@ -74,10 +73,7 @@ discoverResourceTypes:
   - AWS::Redshift::Cluster
 tagExportConfig:
   includeTags:
-    - "asserts-env-name"
     - "kubernetes.io/service-name"
-  envTags:
-    - "asserts-env-name"
 dimensionToLabels:
   - namespace: AWS/EC2
     dimensionName: InstanceId

--- a/src/main/java/ai/asserts/aws/lambda/LambdaFunctionScraper.java
+++ b/src/main/java/ai/asserts/aws/lambda/LambdaFunctionScraper.java
@@ -4,21 +4,28 @@ package ai.asserts.aws.lambda;
 import ai.asserts.aws.AWSClientProvider;
 import ai.asserts.aws.AccountProvider;
 import ai.asserts.aws.AccountProvider.AWSAccount;
+import ai.asserts.aws.MetricNameUtil;
 import ai.asserts.aws.RateLimiter;
 import ai.asserts.aws.ScrapeConfigProvider;
 import ai.asserts.aws.config.NamespaceConfig;
 import ai.asserts.aws.config.ScrapeConfig;
-import ai.asserts.aws.model.CWNamespace;
+import ai.asserts.aws.exporter.MetricProvider;
+import ai.asserts.aws.exporter.MetricSampleBuilder;
 import ai.asserts.aws.resource.Resource;
 import ai.asserts.aws.resource.ResourceTagHelper;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableSortedMap;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.FunctionConfiguration;
 import software.amazon.awssdk.services.lambda.model.ListFunctionsResponse;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -29,43 +36,87 @@ import static ai.asserts.aws.MetricNameUtil.SCRAPE_ACCOUNT_ID_LABEL;
 import static ai.asserts.aws.MetricNameUtil.SCRAPE_NAMESPACE_LABEL;
 import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
 import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
+import static ai.asserts.aws.model.CWNamespace.lambda;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 @Component
 @Slf4j
-public class LambdaFunctionScraper {
+public class LambdaFunctionScraper extends Collector implements MetricProvider {
     private final AccountProvider accountProvider;
     private final ScrapeConfigProvider scrapeConfigProvider;
     private final AWSClientProvider awsClientProvider;
     private final LambdaFunctionBuilder fnBuilder;
     private final ResourceTagHelper resourceTagHelper;
     private final RateLimiter rateLimiter;
+    private final MetricSampleBuilder metricSampleBuilder;
+    private final MetricNameUtil metricNameUtil;
     private final Supplier<Map<String, Map<String, Map<String, LambdaFunction>>>> functionsByRegion;
+    private List<MetricFamilySamples> cache;
 
     public LambdaFunctionScraper(
             AccountProvider accountProvider,
             ScrapeConfigProvider scrapeConfigProvider, AWSClientProvider awsClientProvider,
             ResourceTagHelper resourceTagHelper,
-            LambdaFunctionBuilder fnBuilder, RateLimiter rateLimiter) {
+            LambdaFunctionBuilder fnBuilder, RateLimiter rateLimiter,
+            MetricSampleBuilder metricSampleBuilder, MetricNameUtil metricNameUtil) {
         this.accountProvider = accountProvider;
         this.scrapeConfigProvider = scrapeConfigProvider;
         this.awsClientProvider = awsClientProvider;
         this.resourceTagHelper = resourceTagHelper;
         this.fnBuilder = fnBuilder;
         this.rateLimiter = rateLimiter;
+        this.metricSampleBuilder = metricSampleBuilder;
+        this.metricNameUtil = metricNameUtil;
         this.functionsByRegion = Suppliers.memoizeWithExpiration(this::discoverFunctions,
                 scrapeConfigProvider.getScrapeConfig().getListFunctionsResultCacheTTLMinutes(), MINUTES);
+        this.cache = new ArrayList<>();
     }
 
     public Map<String, Map<String, Map<String, LambdaFunction>>> getFunctions() {
         return functionsByRegion.get();
     }
 
+    @Override
+    public void update() {
+        try {
+            Map<String, Map<String, Map<String, LambdaFunction>>> byAccount = getFunctions();
+            List<Sample> samples = new ArrayList<>();
+            byAccount.forEach((accountId, byRegion) -> byRegion.forEach((region, byName) -> byName.forEach((name, details)
+                    -> {
+                Map<String, String> labels = new TreeMap<>();
+                labels.put(SCRAPE_ACCOUNT_ID_LABEL, accountId);
+                labels.put(SCRAPE_REGION_LABEL, region);
+                labels.put("aws_resource_type", "AWS::Lambda::Function");
+                labels.put("namespace", lambda.getNamespace());
+                labels.put("job", details.getName());
+                labels.put("name", details.getName());
+                labels.put("id", details.getName());
+                if (details.getResource() != null) {
+                    details.getResource().addTagLabels(labels, metricNameUtil);
+                    details.getResource().addEnvLabel(labels, metricNameUtil);
+                }
+                samples.add(metricSampleBuilder.buildSingleSample("aws_resource", labels, 1.0D));
+            })));
+            if (samples.size() > 0) {
+                cache = Collections.singletonList(metricSampleBuilder.buildFamily(samples));
+            } else {
+                cache = new ArrayList<>();
+            }
+        } catch (Exception e) {
+            log.error("Failed to export Lambda function resource metrics", e);
+        }
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        return cache;
+    }
+
     private Map<String, Map<String, Map<String, LambdaFunction>>> discoverFunctions() {
         Map<String, Map<String, Map<String, LambdaFunction>>> functionsByRegion = new TreeMap<>();
         ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
         Optional<NamespaceConfig> lambdaNSOpt = scrapeConfig.getNamespaces().stream()
-                .filter(ns -> CWNamespace.lambda.getNamespace().equals(ns.getName()))
+                .filter(ns -> lambda.getNamespace().equals(ns.getName()))
                 .findFirst();
         for (AWSAccount accountRegion : accountProvider.getAccounts()) {
             lambdaNSOpt.ifPresent(lambdaNS -> accountRegion.getRegions().forEach(region -> {


### PR DESCRIPTION
[ch12326]

Emit Lambda function resource metrics using direct API data rather than config API

Metric from direct API data

<img width="1778" alt="image" src="https://user-images.githubusercontent.com/18289983/169774205-900c6501-deb9-45e6-9fbd-5d83f51d8e1a.png">
