### PR TITLE
Exporter is emitting stale CW Alarm

### DIFF
--- a/config/src/main/java/ai/asserts/aws/config/ScrapeConfig.java
+++ b/config/src/main/java/ai/asserts/aws/config/ScrapeConfig.java
@@ -97,6 +97,9 @@ public class ScrapeConfig {
     @Builder.Default
     private List<DimensionToLabel> dimensionToLabels = new ArrayList<>();
 
+    @Builder.Default
+    private boolean pullCWAlarms = true;
+
     public Optional<NamespaceConfig> getLambdaConfig() {
         if (CollectionUtils.isEmpty(namespaces)) {
             return Optional.empty();

--- a/src/dist/conf/cloudwatch_scrape_config_sample.yml
+++ b/src/dist/conf/cloudwatch_scrape_config_sample.yml
@@ -1,6 +1,7 @@
 delay: 60
 scrapeInterval: 300
 discoverECSTasks: true
+pullCWAlarms: true
 alertForwardUrl:
 tenant:
 ecsTaskScrapeConfigs:

--- a/src/main/java/ai/asserts/aws/MetricTaskManager.java
+++ b/src/main/java/ai/asserts/aws/MetricTaskManager.java
@@ -1,6 +1,7 @@
 package ai.asserts.aws;
 
 import ai.asserts.aws.AccountProvider.AWSAccount;
+import ai.asserts.aws.cloudwatch.alarms.AlarmFetcher;
 import ai.asserts.aws.cloudwatch.alarms.AlarmMetricExporter;
 import ai.asserts.aws.config.MetricConfig;
 import ai.asserts.aws.config.ScrapeConfig;
@@ -33,6 +34,7 @@ public class MetricTaskManager implements InitializingBean {
     private final AutowireCapableBeanFactory beanFactory;
     private final TaskThreadPool taskThreadPool;
     private final AlarmMetricExporter alarmMetricExporter;
+    private final AlarmFetcher alarmFetcher;
 
     /**
      * Maintains the last scrape time for all the metrics of a given scrape interval. The scrapes are
@@ -56,6 +58,7 @@ public class MetricTaskManager implements InitializingBean {
                 .flatMap(map -> map.values().stream())
                 .flatMap(map -> map.values().stream())
                 .forEach(task -> executorService.submit(task::update));
+        executorService.submit(alarmFetcher::update);
 
     }
 

--- a/src/test/java/ai/asserts/aws/cloudwatch/alarms/AlarmFetcherTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/alarms/AlarmFetcherTest.java
@@ -8,11 +8,16 @@ import ai.asserts.aws.AWSClientProvider;
 import ai.asserts.aws.AccountProvider;
 import ai.asserts.aws.AccountProvider.AWSAccount;
 import ai.asserts.aws.RateLimiter;
+import ai.asserts.aws.ScrapeConfigProvider;
 import ai.asserts.aws.config.ScrapeConfig;
 import ai.asserts.aws.exporter.AccountIDProvider;
+import ai.asserts.aws.exporter.BasicMetricCollector;
+import ai.asserts.aws.exporter.MetricSampleBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.prometheus.client.Collector;
+import io.prometheus.client.CollectorRegistry;
 import org.easymock.Capture;
 import org.easymock.EasyMockSupport;
 import org.junit.jupiter.api.BeforeEach;
@@ -35,16 +40,21 @@ import static org.easymock.EasyMock.expect;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AlarmFetcherTest extends EasyMockSupport {
+    public CollectorRegistry collectorRegistry;
     private AccountProvider accountProvider;
     private AWSAccount awsAccount;
     private RateLimiter rateLimiter;
     private AWSClientProvider awsClientProvider;
-    private AlertsProcessor alertsProcessor;
+    private ScrapeConfigProvider scrapeConfigProvider;
     private ScrapeConfig scrapeConfig;
     private CloudWatchClient cloudWatchClient;
     private AccountIDProvider accountIDProvider;
     private AlarmMetricConverter alarmMetricConverter;
+    private BasicMetricCollector basicMetricCollector;
+    private MetricSampleBuilder sampleBuilder;
     private AlarmFetcher testClass;
+    private Collector.MetricFamilySamples.Sample sample;
+    private Collector.MetricFamilySamples familySamples;
     private Instant now;
 
     @BeforeEach
@@ -52,20 +62,27 @@ public class AlarmFetcherTest extends EasyMockSupport {
         now = Instant.now();
         awsAccount = new AWSAccount("123456789", "", "", "", ImmutableSet.of("region"));
         accountProvider = mock(AccountProvider.class);
+        scrapeConfigProvider = mock(ScrapeConfigProvider.class);
         scrapeConfig = mock(ScrapeConfig.class);
-        alertsProcessor = mock(AlertsProcessor.class);
         awsClientProvider = mock(AWSClientProvider.class);
         rateLimiter = mock(RateLimiter.class);
+        sampleBuilder = mock(MetricSampleBuilder.class);
+        collectorRegistry = mock(CollectorRegistry.class);
         cloudWatchClient = mock(CloudWatchClient.class);
         accountIDProvider = mock(AccountIDProvider.class);
         alarmMetricConverter = mock(AlarmMetricConverter.class);
-        testClass = new AlarmFetcher(accountProvider, rateLimiter, awsClientProvider, alertsProcessor,
-                alarmMetricConverter);
+        basicMetricCollector = mock(BasicMetricCollector.class);
+        sample = mock(Collector.MetricFamilySamples.Sample.class);
+        familySamples = mock(Collector.MetricFamilySamples.class);
+        testClass = new AlarmFetcher(accountProvider, awsClientProvider, collectorRegistry, rateLimiter,
+                sampleBuilder, basicMetricCollector, alarmMetricConverter, scrapeConfigProvider);
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void sendAlarmsForRegions() {
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfig.isPullCWAlarms()).andReturn(true);
         expect(accountProvider.getAccounts()).andReturn(ImmutableSet.of(awsAccount));
         expect(accountIDProvider.getAccountId()).andReturn("123456789").anyTimes();
         expect(awsClientProvider.getCloudWatchClient("region", awsAccount))
@@ -92,8 +109,6 @@ public class AlarmFetcherTest extends EasyMockSupport {
                 .stateValue(StateValue.ALARM)
                 .nextToken(null)
                 .build();
-        expect(cloudWatchClient.describeAlarms(request)).andReturn(response);
-        cloudWatchClient.close();
 
         expect(rateLimiter.doWithRateLimit(eq("CloudWatchClient/describeAlarms"),
                 anyObject(SortedMap.class), capture(callbackCapture))).andReturn(response);
@@ -107,12 +122,32 @@ public class AlarmFetcherTest extends EasyMockSupport {
                 .put("region", "region")
                 .put("state", "ALARM")
                 .put("threshold", "10.0")
-                .put("timestamp", now.toString())
                 .build());
-        alertsProcessor.sendAlerts(ImmutableList.of(labels));
+        SortedMap<String, String> labelsHisto = new TreeMap<>(new ImmutableMap.Builder<String, String>()
+                .put("account_id", "123456789")
+                .put("alertname", "alarm1")
+                .put("namespace", "AWS/RDS")
+                .put("region", "region").build());
+        expect(sampleBuilder.buildSingleSample("aws_cloudwatch_alarm", labels, 1.0D))
+                .andReturn(sample);
+        expect(sampleBuilder.buildFamily(ImmutableList.of(sample))).andReturn(familySamples);
+        basicMetricCollector.recordHistogram("aws_exporter_delay_seconds",
+                labelsHisto, 0);
+        cloudWatchClient.close();
         replayAll();
-        testClass.fetchAlarms();
-        assertEquals(response, callbackCapture.getValue().makeCall());
+        testClass.update();
+        assertEquals(ImmutableList.of(familySamples), testClass.collect());
+
+        verifyAll();
+    }
+
+    @Test
+    public void pullAlarm_disabled() {
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+        expect(scrapeConfig.isPullCWAlarms()).andReturn(false);
+        replayAll();
+        testClass.update();
+        assertEquals(ImmutableList.of(), testClass.collect());
 
         verifyAll();
     }


### PR DESCRIPTION
While pulling the cloud watch alarm for the AWS account, we can publish the metric directly compared to the flow where we get a callback from the cloud watch alarm state change notification.
In this flow of pulling the cloud watch alarm convert it to metric and publish directly.
Since we are pulling alarms we will be doing this by default every 1 min.
[ch12437]