### PR TITLE
vmagent security fix

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,5 +1,5 @@
-ARG VM_VERSION=v1.73.1
-FROM victoriametrics/vmagent:$VM_VERSION
+ARG VM_VERSION=v1.80.1
+FROM asserts/vmagent:$VM_VERSION
 
 WORKDIR /
 COPY ./agent-scrape-config.yml /etc/agent-scrape-config.yml


### PR DESCRIPTION
[ch12992]

Use custom docker image of vmagent with amazonlinux as base image. The image was build from source v1.80.0 as follows
* `PKG_TAG=1.80.1 ROOT_IMAGE=amazonlinux:2.0.20220719.0 make package-vmagent`
* `docker tag victoriametrics/vmagent:1.80.1 asserts/vmagent:v1.80.1`

Tested with this in chief and everything seems to be working fine.

<img width="798" alt="image" src="https://user-images.githubusercontent.com/18289983/185612357-918552fc-8c80-4833-b7a2-2323db764dda.png">

<img width="820" alt="image" src="https://user-images.githubusercontent.com/18289983/185612538-cc8269ba-8cac-43a5-842f-f63342a2fabb.png">

<img width="1514" alt="image" src="https://user-images.githubusercontent.com/18289983/185612661-62dadf8b-d57b-4785-b9ae-52a2d7627016.png">

