### PR TITLE
Fix for TargetGroupNotFoundException errors

### DIFF
--- a/config/src/main/java/ai/asserts/aws/config/NamespaceConfig.java
+++ b/config/src/main/java/ai/asserts/aws/config/NamespaceConfig.java
@@ -38,6 +38,8 @@ public class NamespaceConfig {
     @EqualsAndHashCode.Exclude
     private ScrapeConfig scrapeConfig;
     private String name;
+
+    private boolean enabled = true;
     private Integer period;
     private Integer scrapeInterval;
     private Map<String, String> dimensionFilters;

--- a/src/dist/conf/default_relabel_rules.yml
+++ b/src/dist/conf/default_relabel_rules.yml
@@ -33,7 +33,6 @@
   target_label: asserts_request_context
   replacement: $1-$2
 
-
 # AWS Exporter internal metrics
 - source_labels: [ __name__, operation ]
   regex: aws_exporter.+;(.+)

--- a/src/main/java/ai/asserts/aws/MetricTaskManager.java
+++ b/src/main/java/ai/asserts/aws/MetricTaskManager.java
@@ -78,7 +78,7 @@ public class MetricTaskManager implements InitializingBean {
                 metricScrapeTasks.computeIfAbsent(awsAccount.getAccountId(), k -> new TreeMap<>())
                         .computeIfAbsent(region, k -> new TreeMap<>());
                 scrapeConfig.getNamespaces().stream()
-                        .filter(nc -> !CollectionUtils.isEmpty(nc.getMetrics()))
+                        .filter(nc -> nc.isEnabled() && !CollectionUtils.isEmpty(nc.getMetrics()))
                         .flatMap(nc -> nc.getMetrics().stream().map(MetricConfig::getEffectiveScrapeInterval))
                         .forEach(interval -> {
                             String accountId = awsAccount.getAccountId();

--- a/src/main/java/ai/asserts/aws/cloudwatch/query/MetricQueryProvider.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/query/MetricQueryProvider.java
@@ -82,55 +82,63 @@ public class MetricQueryProvider {
         ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
         for (AWSAccount accountRegion : accountProvider.getAccounts()) {
             String account = accountRegion.getAccountId();
-            String assumeRole = accountRegion.getAssumeRole();
-            accountRegion.getRegions().forEach(region -> scrapeConfig.getNamespaces().forEach(ns -> {
-                try {
-                    CloudWatchClient cloudWatchClient = awsClientProvider.getCloudWatchClient(region, accountRegion);
-                    Set<Resource> tagFilteredResources = resourceTagHelper.getFilteredResources(accountRegion, region, ns);
-                    if (!ns.hasTagFilters() || tagFilteredResources.size() > 0) {
+            accountRegion.getRegions().forEach(region -> scrapeConfig.getNamespaces().stream()
+                    .filter(NamespaceConfig::isEnabled)
+                    .forEach(ns -> {
+                        try {
+                            CloudWatchClient cloudWatchClient =
+                                    awsClientProvider.getCloudWatchClient(region, accountRegion);
+                            Set<Resource> tagFilteredResources =
+                                    resourceTagHelper.getFilteredResources(accountRegion, region, ns);
+                            if (!ns.hasTagFilters() || tagFilteredResources.size() > 0) {
 
-                        Map<String, MetricConfig> configuredMetrics = new TreeMap<>();
-                        ns.getMetrics().forEach(metricConfig -> configuredMetrics.put(metricConfig.getName(),
-                                metricConfig));
+                                Map<String, MetricConfig> configuredMetrics = new TreeMap<>();
+                                ns.getMetrics().forEach(metricConfig -> configuredMetrics.put(metricConfig.getName(),
+                                        metricConfig));
 
-                        String nextToken = null;
-                        do {
-                            ListMetricsRequest.Builder builder = ListMetricsRequest.builder()
-                                    .nextToken(nextToken);
-                            Optional<CWNamespace> nsOpt = scrapeConfigProvider.getStandardNamespace(ns.getName());
-                            if (nsOpt.isPresent()) {
-                                String namespace = nsOpt.get().getNamespace();
-                                builder = builder.namespace(namespace);
-                                log.info("Discovering all metrics for region={}, namespace={} ", region, namespace);
-                            } else {
-                                builder = builder.namespace(ns.getName());
-                                log.info("Discovering all metrics for region={}, namespace={} ", region, ns.getName());
+                                String nextToken = null;
+                                do {
+                                    ListMetricsRequest.Builder builder = ListMetricsRequest.builder()
+                                            .nextToken(nextToken);
+                                    Optional<CWNamespace> nsOpt =
+                                            scrapeConfigProvider.getStandardNamespace(ns.getName());
+                                    if (nsOpt.isPresent()) {
+                                        String namespace = nsOpt.get().getNamespace();
+                                        builder = builder.namespace(namespace);
+                                        log.info("Discovering all metrics for region={}, namespace={} ", region,
+                                                namespace);
+                                    } else {
+                                        builder = builder.namespace(ns.getName());
+                                        log.info("Discovering all metrics for region={}, namespace={} ", region,
+                                                ns.getName());
+                                    }
+
+                                    ListMetricsRequest request = builder.build();
+                                    ListMetricsResponse response = rateLimiter.doWithRateLimit(
+                                            "CloudWatchClient/listMetrics",
+                                            operationLabels(account, region, ns),
+                                            () -> cloudWatchClient.listMetrics(request));
+
+                                    if (response.hasMetrics()) {
+                                        // Check if the metric is on a tag filtered resource
+                                        // Also check if the metric matches any dimension filters that might be
+                                        // specified
+                                        response.metrics()
+                                                .stream()
+                                                .filter(metric -> isAConfiguredMetric(configuredMetrics, metric) &&
+                                                        belongsToFilteredResource(ns, tagFilteredResources, metric))
+                                                .forEach(metric -> buildQueries(queriesByAccount, account, region,
+                                                        tagFilteredResources,
+                                                        configuredMetrics.get(metric.metricName()),
+                                                        metric));
+                                    }
+                                    nextToken = response.nextToken();
+                                } while (nextToken != null);
                             }
-
-                            ListMetricsRequest request = builder.build();
-                            ListMetricsResponse response = rateLimiter.doWithRateLimit(
-                                    "CloudWatchClient/listMetrics",
-                                    operationLabels(account, region, ns),
-                                    () -> cloudWatchClient.listMetrics(request));
-
-                            if (response.hasMetrics()) {
-                                // Check if the metric is on a tag filtered resource
-                                // Also check if the metric matches any dimension filters that might be specified
-                                response.metrics()
-                                        .stream()
-                                        .filter(metric -> isAConfiguredMetric(configuredMetrics, metric) &&
-                                                belongsToFilteredResource(ns, tagFilteredResources, metric))
-                                        .forEach(metric -> buildQueries(queriesByAccount, account, region,
-                                                tagFilteredResources, configuredMetrics.get(metric.metricName()),
-                                                metric));
-                            }
-                            nextToken = response.nextToken();
-                        } while (nextToken != null);
-                    }
-                } catch (Exception e) {
-                    log.info("Failed to scrape metrics", e);
-                }
-            }));
+                        } catch (Exception e) {
+                            log.info("Failed to scrape metrics", e);
+                        }
+                    }));
         }
 
         Set<String> metricNames = new HashSet<>();

--- a/src/test/java/ai/asserts/aws/cloudwatch/query/MetricQueryProviderTest.java
+++ b/src/test/java/ai/asserts/aws/cloudwatch/query/MetricQueryProviderTest.java
@@ -91,6 +91,7 @@ public class MetricQueryProviderTest extends EasyMockSupport {
     @Test
     void getMetricQueries() {
         expect(accountProvider.getAccounts()).andReturn(ImmutableSet.of(accountRegion)).anyTimes();
+        expect(namespaceConfig.isEnabled()).andReturn(true).anyTimes();
         ScrapeConfig scrapeConfig = ScrapeConfig.builder()
                 .regions(ImmutableSet.of("region1"))
                 .namespaces(ImmutableList.of(namespaceConfig))
@@ -152,7 +153,7 @@ public class MetricQueryProviderTest extends EasyMockSupport {
                 .regions(ImmutableSet.of("region1"))
                 .namespaces(ImmutableList.of(namespaceConfig))
                 .build();
-
+        expect(namespaceConfig.isEnabled()).andReturn(true).anyTimes();
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
         expect(awsClientProvider.getCloudWatchClient("region1", accountRegion)).andReturn(cloudWatchClient);
 

--- a/src/test/java/ai/asserts/aws/exporter/TargetGroupLBMapProviderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/TargetGroupLBMapProviderTest.java
@@ -199,4 +199,21 @@ public class TargetGroupLBMapProviderTest extends EasyMockSupport {
         assertEquals(ImmutableMap.of(tgResource, lbResource), testClass.getTgToLB());
         verifyAll();
     }
+
+    @Test
+    public void handleMissing() {
+        TargetGroupLBMapProvider testClass = new TargetGroupLBMapProvider(accountProvider, awsClientProvider,
+                resourceMapper, new RateLimiter(metricCollector));
+
+        Resource tgResource = Resource.builder()
+                .name("tg")
+                .arn("tg-arn")
+                .build();
+
+        testClass.getTgToLB().put(tgResource, tgResource);
+        testClass.handleMissingTgs(ImmutableSet.of(tgResource));
+        assertTrue(testClass.getTgToLB().isEmpty());
+        assertTrue(testClass.getMissingTgMap().containsKey(tgResource));
+        assertEquals(tgResource, testClass.getMissingTgMap().get(tgResource));
+    }
 }

--- a/src/test/java/ai/asserts/aws/exporter/TargetGroupLBMapProviderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/TargetGroupLBMapProviderTest.java
@@ -155,7 +155,13 @@ public class TargetGroupLBMapProviderTest extends EasyMockSupport {
                 .build();
 
         Resource tgResource = Resource.builder()
+                .name("tg")
                 .arn("tg-arn")
+                .build();
+
+        Resource tgResource2 = Resource.builder()
+                .name("tg2")
+                .arn("tg-arn2")
                 .build();
 
         Listener listener = Listener.builder()
@@ -169,17 +175,23 @@ public class TargetGroupLBMapProviderTest extends EasyMockSupport {
         DescribeRulesResponse response = DescribeRulesResponse.builder()
                 .rules(Rule.builder()
                         .actions(Action.builder()
-                                .targetGroupArn("tg-arn")
-                                .build())
+                                        .targetGroupArn("tg-arn")
+                                        .build(),
+                                Action.builder()
+                                        .targetGroupArn("tg-arn2")
+                                        .build())
                         .build())
                 .build();
         expect(lbClient.describeRules(request)).andReturn(response);
         metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(SortedMap.class), anyLong());
 
         expect(resourceMapper.map("tg-arn")).andReturn(Optional.of(tgResource));
+        expect(resourceMapper.map("tg-arn2")).andReturn(Optional.of(tgResource2));
 
         TargetGroupLBMapProvider testClass = new TargetGroupLBMapProvider(accountProvider, awsClientProvider,
                 resourceMapper, new RateLimiter(metricCollector));
+
+        testClass.getMissingTgMap().put(tgResource2, tgResource2);
 
         replayAll();
         assertTrue(testClass.getTgToLB().isEmpty());


### PR DESCRIPTION
[ch13398]

* Fix for TargetGroupNotFoundException errors
* Add `enabled` flag for Metric Namespace configs to enable seeded-but-disabled metric configurations