### PR TITLE
Switch to host port for target discovery.

### DIFF
--- a/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
@@ -203,7 +203,7 @@ public class ECSTaskUtil {
                                 labels.putAll(afterRelabeling);
                                 StaticConfig staticConfig = targetsByLabel.computeIfAbsent(
                                         labels, k -> StaticConfig.builder().labels(labels).build());
-                                staticConfig.getTargets().add(format("%s:%d", ipAddress, port.containerPort()));
+                                staticConfig.getTargets().add(format("%s:%d", ipAddress, port.hostPort()));
                             }
                         });
                     } else if (scrapeConfig.isDiscoverAllECSTasksByDefault()) {
@@ -219,7 +219,7 @@ public class ECSTaskUtil {
                         StaticConfig staticConfig = targetsByLabel.computeIfAbsent(
                                 labels, k -> StaticConfig.builder().labels(labels).build());
                         cD.portMappings().forEach(port ->
-                                staticConfig.getTargets().add(format("%s:%d", ipAddress, port.containerPort())));
+                                staticConfig.getTargets().add(format("%s:%d", ipAddress, port.hostPort())));
                     }
                 });
             }

--- a/src/test/java/ai/asserts/aws/exporter/ECSTaskUtilTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSTaskUtilTest.java
@@ -272,12 +272,12 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                 () -> assertEquals(ImmutableSet.of("api-server", "model-builder"), staticConfigs.stream()
                         .map(sc -> sc.getLabels().getContainer())
                         .collect(Collectors.toSet())),
-                () -> assertEquals(ImmutableSet.of("10.20.30.40:8081", "10.20.30.40:8082"),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:52342", "10.20.30.40:52343"),
                         staticConfigs.stream()
                                 .filter(sc -> sc.getLabels().getContainer().equals("api-server"))
                                 .map(StaticConfig::getTargets)
                                 .findFirst().get()),
-                () -> assertEquals(ImmutableSet.of("10.20.30.40:8080"),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:52341"),
                         staticConfigs.stream()
                                 .filter(sc -> sc.getLabels().getContainer().equals("model-builder"))
                                 .map(StaticConfig::getTargets)
@@ -379,12 +379,12 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                                 .filter(sc -> sc.getLabels().getContainer().equals("model-builder"))
                                 .map(sc -> sc.getLabels().getMetricsPath())
                                 .findFirst().get()),
-                () -> assertEquals(ImmutableSet.of("10.20.30.40:8081", "10.20.30.40:8082"),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:52342", "10.20.30.40:52343"),
                         staticConfigs.stream()
                                 .filter(sc -> sc.getLabels().getContainer().equals("api-server"))
                                 .map(StaticConfig::getTargets)
                                 .findFirst().get()),
-                () -> assertEquals(ImmutableSet.of("10.20.30.40:8080"),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:52341"),
                         staticConfigs.stream()
                                 .filter(sc -> sc.getLabels().getContainer().equals("model-builder"))
                                 .map(StaticConfig::getTargets)
@@ -462,17 +462,17 @@ public class ECSTaskUtilTest extends EasyMockSupport {
 
         Optional<StaticConfig> apiServer_8081 = staticConfigs.stream()
                 .filter(sc -> sc.getLabels().getContainer().equals("api-server"))
-                .filter(sc -> sc.getTargets().contains("10.20.30.40:8081"))
+                .filter(sc -> sc.getTargets().contains("10.20.30.40:52342"))
                 .findFirst();
 
         Optional<StaticConfig> apiServer_8082 = staticConfigs.stream()
                 .filter(sc -> sc.getLabels().getContainer().equals("api-server"))
-                .filter(sc -> sc.getTargets().contains("10.20.30.40:8082"))
+                .filter(sc -> sc.getTargets().contains("10.20.30.40:52343"))
                 .findFirst();
 
         Optional<StaticConfig> modelBuilder = staticConfigs.stream()
                 .filter(sc -> sc.getLabels().getContainer().equals("model-builder"))
-                .filter(sc -> sc.getTargets().contains("10.20.30.40:8080"))
+                .filter(sc -> sc.getTargets().contains("10.20.30.40:52341"))
                 .findFirst();
 
         assertAll(
@@ -577,7 +577,7 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                 () -> assertEquals("service-task-id", staticConfigs.get(0).getLabels().getTaskId()),
                 () -> assertEquals("/prometheus/metrics", staticConfigs.get(0).getLabels().getMetricsPath()),
                 () -> assertEquals("api-server", staticConfigs.get(0).getLabels().getContainer()),
-                () -> assertEquals(ImmutableSet.of("10.20.30.40:8081"),
+                () -> assertEquals(ImmutableSet.of("10.20.30.40:52342"),
                         staticConfigs.get(0).getTargets())
         );
         verifyAll();


### PR DESCRIPTION
[ch13709]
Switch to host port for target discovery. This should work for all [network modes](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html).