### PR TITLE
Retrieve AWS Account configuration from API Server

### DIFF
--- a/config/src/main/java/ai/asserts/aws/config/ScrapeConfig.java
+++ b/config/src/main/java/ai/asserts/aws/config/ScrapeConfig.java
@@ -87,9 +87,6 @@ public class ScrapeConfig {
     private boolean discoverOnlySubnetTasks = false;
 
     @Builder.Default
-    private Set<String> pauseAccounts = new TreeSet<>();
-
-    @Builder.Default
     private Set<String> discoverResourceTypes = new TreeSet<>();
 
     @Builder.Default
@@ -126,6 +123,9 @@ public class ScrapeConfig {
 
     @Builder.Default
     private boolean logScrapeConfig = false;
+
+    @Builder.Default
+    private boolean scrapeCurrentAccount = true;
 
     @JsonIgnore
     public Optional<NamespaceConfig> getLambdaConfig() {

--- a/src/main/java/ai/asserts/aws/AWSClientProvider.java
+++ b/src/main/java/ai/asserts/aws/AWSClientProvider.java
@@ -575,10 +575,13 @@ public class AWSClientProvider {
                 stsClientBuilder = stsClientBuilder.credentialsProvider(credentialsOpt.get());
             }
             try (StsClient build = stsClientBuilder.build()) {
-                AssumeRoleResponse response = build.assumeRole(AssumeRoleRequest.builder()
+                AssumeRoleRequest.Builder reqBuilder = AssumeRoleRequest.builder()
                         .roleSessionName("session1")
-                        .roleArn(account.getAssumeRole())
-                        .build());
+                        .roleArn(account.getAssumeRole());
+                if(hasLength(account.getExternalId())) {
+                    reqBuilder = reqBuilder.externalId(account.getExternalId());
+                }
+                AssumeRoleResponse response = build.assumeRole(reqBuilder.build());
                 credentials = AWSSessionConfig.builder()
                         .accessKeyId(response.credentials().accessKeyId())
                         .secretAccessKey(response.credentials().secretAccessKey())

--- a/src/main/java/ai/asserts/aws/AccountProvider.java
+++ b/src/main/java/ai/asserts/aws/AccountProvider.java
@@ -7,8 +7,10 @@ package ai.asserts.aws;
 import ai.asserts.aws.config.ScrapeConfig;
 import ai.asserts.aws.exporter.AccountIDProvider;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Suppliers;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +18,11 @@ import lombok.Setter;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -25,6 +31,7 @@ import java.util.TreeSet;
 import java.util.function.Supplier;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.springframework.util.CollectionUtils.isEmpty;
 
 @Component
 @Slf4j
@@ -32,6 +39,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 public class AccountProvider {
     private final AccountIDProvider accountIDProvider;
     private final ScrapeConfigProvider scrapeConfigProvider;
+    private final RestTemplate restTemplate;
     private final Supplier<Set<AWSAccount>> accountsCache =
             Suppliers.memoizeWithExpiration(this::getAccountsInternal, 5, MINUTES);
 
@@ -43,26 +51,56 @@ public class AccountProvider {
         return accountsCache.get();
     }
 
-    public boolean pauseCurrentAccount() {
-        ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
-        String accountId = accountIDProvider.getAccountId();
-        return scrapeConfig.getPauseAccounts().contains(accountId);
-    }
-
     private Set<AWSAccount> getAccountsInternal() {
         ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
         Set<AWSAccount> accountRegions = new LinkedHashSet<>();
-        if (!pauseCurrentAccount()) {
+        Set<String> regions = scrapeConfig.getRegions();
+        if (regions.isEmpty()) {
+            regions = new TreeSet<>();
+            regions.add("us-west-2");
+        }
+        if (scrapeConfig.isScrapeCurrentAccount()) {
             String accountId = accountIDProvider.getAccountId();
-            Set<String> regions = scrapeConfig.getRegions();
-            if (regions.isEmpty()) {
-                regions = new TreeSet<>();
-                regions.add("us-west-2");
-            }
-            accountRegions.add(new AWSAccount(accountId, null, null, null, regions));
+            AWSAccount ac = new AWSAccount(accountId, null, null, null, regions);
+            accountRegions.add(ac);
             log.info("Scraping AWS Accounts {}", accountRegions);
         }
+
+        // Get Configured AWS Accounts
+        String cloudwatchConfigUrl = scrapeConfigProvider.getAssertsTenantBaseUrl() +
+                "/api-server/v1/config/cloudwatch";
+        ResponseEntity<CloudwatchConfigs> response = restTemplate.exchange(cloudwatchConfigUrl,
+                HttpMethod.GET,
+                scrapeConfigProvider.createAssertsAuthHeader(),
+                new ParameterizedTypeReference<CloudwatchConfigs>() {
+                });
+        if (response.getStatusCode().is2xxSuccessful()) {
+            Set<String> finalRegions = regions;
+            if (response.getBody() != null && !isEmpty(response.getBody().getCloudWatchConfigs())) {
+                response.getBody().getCloudWatchConfigs()
+                        .stream()
+                        .filter(awsAccount -> {
+                            if (awsAccount.paused) {
+                                log.info("Account {} is paused", awsAccount.accountId);
+                            }
+                            return !awsAccount.paused;
+                        })
+                        .forEach(awsAccount -> {
+                            awsAccount.getRegions().addAll(finalRegions);
+                            accountRegions.add(awsAccount);
+                        });
+            }
+
+        }
         return accountRegions;
+    }
+
+    @EqualsAndHashCode
+    @Getter
+    @SuperBuilder
+    @ToString
+    public static class CloudwatchConfigs {
+        List<AWSAccount> cloudWatchConfigs;
     }
 
     @AllArgsConstructor
@@ -71,13 +109,25 @@ public class AccountProvider {
     @ToString
     @SuperBuilder
     public static class AWSAccount {
+        // Use different json field name to match property from API Response
+        @JsonProperty("accountID")
         private final String accountId;
+        private final String name;
         @ToString.Exclude
         private final String accessId;
         @ToString.Exclude
         private final String secretKey;
+        // Use different json field name to match property from API Response
+        @JsonProperty("assumeRoleARN")
         private final String assumeRole;
-        private final Set<String> regions;
+        private final String externalId;
+        private final boolean paused;
+        @Builder.Default
+        private final Set<String> regions = new TreeSet<>();
+
+        public AWSAccount(String accountId, String accessId, String secretKey, String assumeRole, Set<String> regions) {
+            this(accountId, null, accessId, secretKey, assumeRole, null, false, regions);
+        }
     }
 
     @Getter

--- a/src/main/java/ai/asserts/aws/ApiServerConstants.java
+++ b/src/main/java/ai/asserts/aws/ApiServerConstants.java
@@ -8,4 +8,6 @@ public interface ApiServerConstants {
     String ASSERTS_API_SERVER_URL = "ASSERTS_API_SERVER_URL";
     String ASSERTS_USER = "ASSERTS_USER";
     String ASSERTS_PASSWORD = "ASSERTS_PASSWORD";
+
+    String ASSERTS_TENANT_HEADER = "X-Asserts-Tenant";
 }

--- a/src/main/java/ai/asserts/aws/MetadataTaskManager.java
+++ b/src/main/java/ai/asserts/aws/MetadataTaskManager.java
@@ -66,8 +66,6 @@ public class MetadataTaskManager implements InitializingBean {
     private final DynamoDBExporter dynamoDBExporter;
     private final SNSTopicExporter snsTopicExporter;
 
-    private final AccountProvider accountProvider;
-
     private final EMRExporter emrExporter;
 
     @Getter
@@ -103,32 +101,29 @@ public class MetadataTaskManager implements InitializingBean {
             log.info("Not primary exporter. Skip meta data scraping.");
             return;
         }
-        if (accountProvider.pauseCurrentAccount()) {
-            log.info("Skipping all scheduled meta data tasks. All processing paused.");
-        } else {
-            taskThreadPool.getExecutorService().submit(lambdaFunctionScraper::update);
-            taskThreadPool.getExecutorService().submit(lambdaCapacityExporter::update);
-            taskThreadPool.getExecutorService().submit(lambdaEventSourceExporter::update);
-            taskThreadPool.getExecutorService().submit(lambdaInvokeConfigExporter::update);
-            taskThreadPool.getExecutorService().submit(targetGroupLBMapProvider::update);
-            taskThreadPool.getExecutorService().submit(lbToASGRelationBuilder::updateRouting);
-            taskThreadPool.getExecutorService().submit(relationExporter::update);
-            taskThreadPool.getExecutorService().submit(ec2ToEBSVolumeExporter::update);
-            taskThreadPool.getExecutorService().submit(apiGatewayToLambdaBuilder::update);
-            taskThreadPool.getExecutorService().submit(kinesisAnalyticsExporter::update);
-            taskThreadPool.getExecutorService().submit(kinesisFirehoseExporter::update);
-            taskThreadPool.getExecutorService().submit(s3BucketExporter::update);
-            taskThreadPool.getExecutorService().submit(redshiftExporter::update);
-            taskThreadPool.getExecutorService().submit(sqsQueueExporter::update);
-            taskThreadPool.getExecutorService().submit(kinesisStreamExporter::update);
-            taskThreadPool.getExecutorService().submit(loadBalancerExporter::update);
-            taskThreadPool.getExecutorService().submit(rdsExporter::update);
-            taskThreadPool.getExecutorService().submit(dynamoDBExporter::update);
-            taskThreadPool.getExecutorService().submit(snsTopicExporter::update);
-            taskThreadPool.getExecutorService().submit(() ->
-                    logScrapeTasks.forEach(LambdaLogMetricScrapeTask::update));
-            taskThreadPool.getExecutorService().submit(emrExporter::update);
-        }
+
+        taskThreadPool.getExecutorService().submit(lambdaFunctionScraper::update);
+        taskThreadPool.getExecutorService().submit(lambdaCapacityExporter::update);
+        taskThreadPool.getExecutorService().submit(lambdaEventSourceExporter::update);
+        taskThreadPool.getExecutorService().submit(lambdaInvokeConfigExporter::update);
+        taskThreadPool.getExecutorService().submit(targetGroupLBMapProvider::update);
+        taskThreadPool.getExecutorService().submit(lbToASGRelationBuilder::updateRouting);
+        taskThreadPool.getExecutorService().submit(relationExporter::update);
+        taskThreadPool.getExecutorService().submit(ec2ToEBSVolumeExporter::update);
+        taskThreadPool.getExecutorService().submit(apiGatewayToLambdaBuilder::update);
+        taskThreadPool.getExecutorService().submit(kinesisAnalyticsExporter::update);
+        taskThreadPool.getExecutorService().submit(kinesisFirehoseExporter::update);
+        taskThreadPool.getExecutorService().submit(s3BucketExporter::update);
+        taskThreadPool.getExecutorService().submit(redshiftExporter::update);
+        taskThreadPool.getExecutorService().submit(sqsQueueExporter::update);
+        taskThreadPool.getExecutorService().submit(kinesisStreamExporter::update);
+        taskThreadPool.getExecutorService().submit(loadBalancerExporter::update);
+        taskThreadPool.getExecutorService().submit(rdsExporter::update);
+        taskThreadPool.getExecutorService().submit(dynamoDBExporter::update);
+        taskThreadPool.getExecutorService().submit(snsTopicExporter::update);
+        taskThreadPool.getExecutorService().submit(() ->
+                logScrapeTasks.forEach(LambdaLogMetricScrapeTask::update));
+        taskThreadPool.getExecutorService().submit(emrExporter::update);
     }
 
     @SuppressWarnings("unused")
@@ -137,10 +132,6 @@ public class MetadataTaskManager implements InitializingBean {
     @Timed(description = "Time spent scraping AWS Resource meta data from all regions", histogram = true)
     public void perMinute() {
         taskThreadPool.getExecutorService().submit(scrapeConfigProvider::update);
-        if (accountProvider.pauseCurrentAccount()) {
-            log.info("Skipping ECS Service Discovery. All processing paused.");
-        } else {
-            taskThreadPool.getExecutorService().submit(ecsServiceDiscoveryExporter::update);
-        }
+        taskThreadPool.getExecutorService().submit(ecsServiceDiscoveryExporter::update);
     }
 }

--- a/src/main/java/ai/asserts/aws/MetricTaskManager.java
+++ b/src/main/java/ai/asserts/aws/MetricTaskManager.java
@@ -55,9 +55,7 @@ public class MetricTaskManager implements InitializingBean {
             initialDelayString = "${aws.metric.scrape.manager.task.initialDelay:5000}")
     @Timed(description = "Time spent scraping cloudwatch metrics from all regions", histogram = true)
     public void triggerScrapes() {
-        if (accountProvider.pauseCurrentAccount()) {
-            log.info("Skipping Metric Scrapes and Alarm Scrape. All processing paused.");
-        } else if (ecsServiceDiscoveryExporter.isPrimaryExporter()) {
+        if (ecsServiceDiscoveryExporter.isPrimaryExporter()) {
             updateScrapeTasks();
             ExecutorService executorService = taskThreadPool.getExecutorService();
             metricScrapeTasks.values().stream()

--- a/src/test/java/ai/asserts/aws/AccountProviderTest.java
+++ b/src/test/java/ai/asserts/aws/AccountProviderTest.java
@@ -5,13 +5,19 @@
 package ai.asserts.aws;
 
 import ai.asserts.aws.AccountProvider.AWSAccount;
+import ai.asserts.aws.AccountProvider.CloudwatchConfigs;
 import ai.asserts.aws.config.ScrapeConfig;
 import ai.asserts.aws.exporter.AccountIDProvider;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedSet;
 import org.easymock.EasyMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
 
 import static org.easymock.EasyMock.expect;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -20,60 +26,176 @@ public class AccountProviderTest extends EasyMockSupport {
     private AccountIDProvider accountIDProvider;
     private ScrapeConfigProvider scrapeConfigProvider;
     private ScrapeConfig scrapeConfig;
+    private HttpEntity<String> mockEntity;
+    private RestTemplate restTemplate;
     private AccountProvider testClass;
 
     @BeforeEach
     public void setup() {
         accountIDProvider = mock(AccountIDProvider.class);
         scrapeConfigProvider = mock(ScrapeConfigProvider.class);
+        mockEntity = mock(HttpEntity.class);
         scrapeConfig = mock(ScrapeConfig.class);
-        testClass = new AccountProvider(accountIDProvider, scrapeConfigProvider);
+        restTemplate = mock(RestTemplate.class);
+        testClass = new AccountProvider(accountIDProvider, scrapeConfigProvider, restTemplate);
     }
 
     @Test
-    public void getAccounts_ApiServerCredentialsMissing() {
+    public void getAccounts_NoConfiguredAccounts_SkipCurrentAccount() {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
-        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region")).anyTimes();
-        expect(scrapeConfig.getPauseAccounts()).andReturn(ImmutableSortedSet.of());
-        expect(accountIDProvider.getAccountId()).andReturn("account1").anyTimes();
+        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("us-west-2"));
+        expect(scrapeConfig.isScrapeCurrentAccount()).andReturn(false);
+        expect(accountIDProvider.getAccountId()).andReturn("default-account").anyTimes();
+        expect(scrapeConfigProvider.getAssertsTenantBaseUrl()).andReturn("url");
+        expect(scrapeConfigProvider.createAssertsAuthHeader()).andReturn(mockEntity);
+        expect(restTemplate.exchange("url/api-server/v1/config/cloudwatch", HttpMethod.GET, mockEntity,
+                new ParameterizedTypeReference<CloudwatchConfigs>() {
+                })).andReturn(ResponseEntity.ok(CloudwatchConfigs.builder()
+                .cloudWatchConfigs(ImmutableList.of())
+                .build()));
+
         replayAll();
-        assertEquals(
-                ImmutableSet.of(new AWSAccount("account1", null, null, null,
-                        ImmutableSet.of("region"))),
-                testClass.getAccounts()
-        );
+        assertEquals(ImmutableSet.of(), testClass.getAccounts());
         verifyAll();
     }
 
     @Test
-    public void getAccounts_ApiServerCredentialsPresent() {
-        expect(scrapeConfig.getPauseAccounts()).andReturn(ImmutableSortedSet.of());
+    public void getAccounts_NoConfiguredAccounts_UseCurrentAccount() {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
-        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region")).anyTimes();
-        expect(accountIDProvider.getAccountId()).andReturn("account1").anyTimes();
+        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("us-west-2"));
+        expect(scrapeConfig.isScrapeCurrentAccount()).andReturn(true);
+        expect(accountIDProvider.getAccountId()).andReturn("default-account").anyTimes();
+        expect(scrapeConfigProvider.getAssertsTenantBaseUrl()).andReturn("url");
+        expect(scrapeConfigProvider.createAssertsAuthHeader()).andReturn(mockEntity);
+        expect(restTemplate.exchange("url/api-server/v1/config/cloudwatch", HttpMethod.GET, mockEntity,
+                new ParameterizedTypeReference<CloudwatchConfigs>() {
+                })).andReturn(ResponseEntity.ok(CloudwatchConfigs.builder()
+                .cloudWatchConfigs(ImmutableList.of())
+                .build()));
 
         replayAll();
-        assertEquals(
-                ImmutableSet.of(
-                        new AWSAccount("account1", null, null, null, ImmutableSet.of("region"))
-                ),
-                testClass.getAccounts()
-        );
+        assertEquals(ImmutableSet.of(
+                AWSAccount.builder()
+                        .accountId("default-account")
+                        .regions(ImmutableSet.of("us-west-2"))
+                        .build()
+        ), testClass.getAccounts());
         verifyAll();
     }
 
     @Test
-    public void getAccounts_ApiServerCredentialsPresent_ProcessingPaused() {
-        expect(accountIDProvider.getAccountId()).andReturn("account1").anyTimes();
-        expect(scrapeConfig.getPauseAccounts()).andReturn(ImmutableSortedSet.of("account1"));
+    public void getAccounts_ConfiguredAccounts_SkipCurrentAccount() {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
-        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("region")).anyTimes();
+        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("us-west-2"));
+        expect(scrapeConfig.isScrapeCurrentAccount()).andReturn(false);
+        expect(accountIDProvider.getAccountId()).andReturn("default-account").anyTimes();
+        expect(scrapeConfigProvider.getAssertsTenantBaseUrl()).andReturn("url");
+        expect(scrapeConfigProvider.createAssertsAuthHeader()).andReturn(mockEntity);
+        expect(restTemplate.exchange("url/api-server/v1/config/cloudwatch", HttpMethod.GET, mockEntity,
+                new ParameterizedTypeReference<CloudwatchConfigs>() {
+                })).andReturn(ResponseEntity.ok(CloudwatchConfigs.builder()
+                .cloudWatchConfigs(ImmutableList.of(
+                        AWSAccount.builder()
+                                .accountId("account-1")
+                                .name("dev")
+                                .assumeRole("role")
+                                .externalId("external-id")
+                                .build()
+                ))
+                .build()));
 
         replayAll();
-        assertEquals(
-                ImmutableSet.of(),
-                testClass.getAccounts()
-        );
+        assertEquals(ImmutableSet.of(AWSAccount.builder()
+                .accountId("account-1")
+                .name("dev")
+                .assumeRole("role")
+                .externalId("external-id")
+                .regions(ImmutableSet.of("us-west-2"))
+                .build()
+        ), testClass.getAccounts());
+        verifyAll();
+    }
+
+    @Test
+    public void getAccounts_ConfiguredAccounts_UseCurrentAccount() {
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
+        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("us-west-2"));
+        expect(scrapeConfig.isScrapeCurrentAccount()).andReturn(true);
+        expect(accountIDProvider.getAccountId()).andReturn("default-account").anyTimes();
+        expect(scrapeConfigProvider.getAssertsTenantBaseUrl()).andReturn("url");
+        expect(scrapeConfigProvider.createAssertsAuthHeader()).andReturn(mockEntity);
+        expect(restTemplate.exchange("url/api-server/v1/config/cloudwatch", HttpMethod.GET, mockEntity,
+                new ParameterizedTypeReference<CloudwatchConfigs>() {
+                })).andReturn(ResponseEntity.ok(CloudwatchConfigs.builder()
+                .cloudWatchConfigs(ImmutableList.of(
+                        AWSAccount.builder()
+                                .accountId("account-1")
+                                .name("dev")
+                                .assumeRole("role")
+                                .externalId("external-id")
+                                .build()
+                ))
+                .build()));
+
+        replayAll();
+        assertEquals(ImmutableSet.of(
+                AWSAccount.builder()
+                        .accountId("default-account")
+                        .regions(ImmutableSet.of("us-west-2"))
+                        .build(),
+                AWSAccount.builder()
+                        .accountId("account-1")
+                        .name("dev")
+                        .assumeRole("role")
+                        .externalId("external-id")
+                        .regions(ImmutableSet.of("us-west-2"))
+                        .build()
+        ), testClass.getAccounts());
+        verifyAll();
+    }
+
+    @Test
+    public void getAccounts_ConfiguredAccounts_SomePaused_UseCurrentAccount() {
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
+        expect(scrapeConfig.getRegions()).andReturn(ImmutableSet.of("us-west-2"));
+        expect(scrapeConfig.isScrapeCurrentAccount()).andReturn(true);
+        expect(accountIDProvider.getAccountId()).andReturn("default-account").anyTimes();
+        expect(scrapeConfigProvider.getAssertsTenantBaseUrl()).andReturn("url");
+        expect(scrapeConfigProvider.createAssertsAuthHeader()).andReturn(mockEntity);
+        expect(restTemplate.exchange("url/api-server/v1/config/cloudwatch", HttpMethod.GET, mockEntity,
+                new ParameterizedTypeReference<CloudwatchConfigs>() {
+                })).andReturn(ResponseEntity.ok(CloudwatchConfigs.builder()
+                .cloudWatchConfigs(ImmutableList.of(
+                        AWSAccount.builder()
+                                .accountId("account-1")
+                                .name("dev")
+                                .assumeRole("role")
+                                .externalId("external-id")
+                                .build(),
+                        AWSAccount.builder()
+                                .accountId("account-2")
+                                .name("prod")
+                                .assumeRole("role")
+                                .externalId("external-id")
+                                .paused(true)
+                                .build()
+                ))
+                .build()));
+
+        replayAll();
+        assertEquals(ImmutableSet.of(
+                AWSAccount.builder()
+                        .accountId("default-account")
+                        .regions(ImmutableSet.of("us-west-2"))
+                        .build(),
+                AWSAccount.builder()
+                        .accountId("account-1")
+                        .name("dev")
+                        .assumeRole("role")
+                        .externalId("external-id")
+                        .regions(ImmutableSet.of("us-west-2"))
+                        .build()
+        ), testClass.getAccounts());
         verifyAll();
     }
 

--- a/src/test/java/ai/asserts/aws/MetadataTaskManagerTest.java
+++ b/src/test/java/ai/asserts/aws/MetadataTaskManagerTest.java
@@ -74,7 +74,6 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
     private RDSExporter rdsExporter;
     private DynamoDBExporter dynamoDBExporter;
     private SNSTopicExporter snsTopicExporter;
-    private AccountProvider accountProvider;
     private EMRExporter emrExporter;
     private MetadataTaskManager testClass;
 
@@ -109,7 +108,6 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
         rdsExporter = mock(RDSExporter.class);
         dynamoDBExporter = mock(DynamoDBExporter.class);
         snsTopicExporter = mock(SNSTopicExporter.class);
-        accountProvider = mock(AccountProvider.class);
         emrExporter = mock(EMRExporter.class);
         testClass = new MetadataTaskManager(
                 collectorRegistry, lambdaFunctionScraper, lambdaCapacityExporter, lambdaEventSourceExporter,
@@ -118,7 +116,7 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
                 apiGatewayToLambdaBuilder, kinesisAnalyticsExporter, kinesisFirehoseExporter,
                 s3BucketExporter, taskThreadPool, scrapeConfigProvider, ecsServiceDiscoveryExporter, redshiftExporter,
                 sqsQueueExporter, kinesisStreamExporter, loadBalancerExporter, rdsExporter, dynamoDBExporter,
-                snsTopicExporter, accountProvider, emrExporter);
+                snsTopicExporter, emrExporter);
     }
 
     @Test
@@ -154,7 +152,6 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
     public void updateMetadata_primaryExporter() {
         testClass.getLogScrapeTasks().add(logMetricScrapeTask);
 
-        expect(accountProvider.pauseCurrentAccount()).andReturn(false);
         expect(ecsServiceDiscoveryExporter.isPrimaryExporter()).andReturn(true);
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
         expect(taskThreadPool.getExecutorService()).andReturn(executorService).anyTimes();
@@ -268,25 +265,9 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
 
     @Test
     @SuppressWarnings("null")
-    public void updateMetadata_processingPaused() {
-        testClass.getLogScrapeTasks().add(logMetricScrapeTask);
-        expect(accountProvider.pauseCurrentAccount()).andReturn(true);
-        expect(ecsServiceDiscoveryExporter.isPrimaryExporter()).andReturn(true);
-        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
-
-        replayAll();
-
-        testClass.updateMetadata();
-
-        verifyAll();
-    }
-
-    @Test
-    @SuppressWarnings("null")
     public void perMinuteTasks() {
         Capture<Runnable> capture0 = newCapture();
         Capture<Runnable> capture1 = newCapture();
-        expect(accountProvider.pauseCurrentAccount()).andReturn(false);
         expect(taskThreadPool.getExecutorService()).andReturn(executorService).anyTimes();
         expect(executorService.submit(capture(capture0))).andReturn(null);
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();

--- a/src/test/java/ai/asserts/aws/MetricTaskManagerTest.java
+++ b/src/test/java/ai/asserts/aws/MetricTaskManagerTest.java
@@ -84,7 +84,6 @@ public class MetricTaskManagerTest extends EasyMockSupport {
         Capture<Runnable> capture3 = newCapture();
         expect(ecsServiceDiscoveryExporter.isPrimaryExporter()).andReturn(true);
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
-        expect(accountProvider.pauseCurrentAccount()).andReturn(false).anyTimes();
         expect(taskThreadPool.getExecutorService()).andReturn(executorService).anyTimes();
 
         expect(executorService.submit(capture(capture1))).andReturn(null);
@@ -101,28 +100,6 @@ public class MetricTaskManagerTest extends EasyMockSupport {
         capture1.getValue().run();
         capture2.getValue().run();
         capture3.getValue().run();
-
-        verifyAll();
-    }
-
-    @Test
-    void triggerScrapes_processingPaused() {
-        testClass = new MetricTaskManager(accountProvider, scrapeConfigProvider, collectorRegistry, beanFactory,
-                taskThreadPool, alarmMetricExporter, alarmFetcher, ecsServiceDiscoveryExporter) {
-            @Override
-            void updateScrapeTasks() {
-            }
-        };
-        testClass.getMetricScrapeTasks().put("account", ImmutableMap.of(
-                "region1", ImmutableMap.of(300, metricScrapeTask),
-                "region2", ImmutableMap.of(300, metricScrapeTask)
-        ));
-
-        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
-        expect(accountProvider.pauseCurrentAccount()).andReturn(true).anyTimes();
-
-        replayAll();
-        testClass.triggerScrapes();
 
         verifyAll();
     }

--- a/src/test/java/ai/asserts/aws/ScrapeConfigProviderTest.java
+++ b/src/test/java/ai/asserts/aws/ScrapeConfigProviderTest.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static ai.asserts.aws.ApiServerConstants.ASSERTS_TENANT_HEADER;
 import static org.easymock.EasyMock.expect;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -178,8 +179,9 @@ public class ScrapeConfigProviderTest extends EasyMockSupport {
     @Test
     void loadConfigFromS3() throws IOException {
         FileInputStream fis = new FileInputStream("src/test/resources/cloudwatch_scrape_config.yml");
-        ScrapeConfig scrapeConfig = new ObjectMapperFactory().getObjectMapper().readValue(fis, new TypeReference<ScrapeConfig>() {
-        });
+        ScrapeConfig scrapeConfig =
+                new ObjectMapperFactory().getObjectMapper().readValue(fis, new TypeReference<ScrapeConfig>() {
+                });
         scrapeConfig.getRelabelConfigs().addAll(relabelConfigs);
         scrapeConfig.validateConfig();
 
@@ -222,8 +224,9 @@ public class ScrapeConfigProviderTest extends EasyMockSupport {
         HttpHeaders headers = new HttpHeaders();
         headers.setBasicAuth("user", "key");
         headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.add(ASSERTS_TENANT_HEADER, "user");
         HttpEntity<?> httpEntity = new HttpEntity<>(headers);
-        ResponseEntity<ScrapeConfig> response = new ResponseEntity(scrapeConfig, HttpStatus.OK);
+        ResponseEntity<ScrapeConfig> response = new ResponseEntity<>(scrapeConfig, HttpStatus.OK);
         expect(restTemplate.exchange("host/api-server/v1/config/aws-exporter",
                 HttpMethod.GET,
                 httpEntity,

--- a/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
@@ -309,7 +309,7 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
             }
 
             @Override
-            List<StaticConfig> buildTargetsInCluster(ScrapeConfig sc, EcsClient client,
+            List<StaticConfig> buildTargetsInCluster(AWSAccount account, ScrapeConfig sc, EcsClient client,
                                                      Resource _cluster,
                                                      Set<ResourceRelation> routing,
                                                      List<Sample> samples) {
@@ -377,7 +377,8 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
             }
 
             @Override
-            List<StaticConfig> buildTargetsInCluster(ScrapeConfig sc, EcsClient client, Resource _cluster,
+            List<StaticConfig> buildTargetsInCluster(AWSAccount awsAccount, ScrapeConfig sc, EcsClient client,
+                                                     Resource _cluster,
                                                      Set<ResourceRelation> routing,
                                                      List<Sample> samples) {
                 assertEquals(scrapeConfig, sc);
@@ -527,7 +528,7 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
         testClass.getSubnetDetails().set(new SubnetDetails());
         assertEquals(
                 ImmutableList.of(mockStaticConfig, mockStaticConfig, mockStaticConfig),
-                testClass.buildTargetsInCluster(scrapeConfig, ecsClient, cluster, newRouting, samples));
+                testClass.buildTargetsInCluster(account, scrapeConfig, ecsClient, cluster, newRouting, samples));
 
         assertEquals(ImmutableSet.of(mockRelation), newRouting);
 


### PR DESCRIPTION
[ch14527]

* Retrieve AWS Account configuration from API Server. Use AssumeRole/ExternalId if available
* Optionally, scrape the current account on which the exporter is running
* Pause accounts for which pause is requested.