### PR TITLE
Emit ECS Task Meta metric

### DIFF
--- a/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
@@ -93,7 +93,8 @@ public class ECSTaskUtil {
         if (service.isPresent()) {
             labelsBuilder = Labels.builder()
                     .workload(service.get().getName())
-                    .taskId(service.get().getName() + "-" + taskResource.getName())
+                    .taskId(taskResource.getName())
+                    .pod(service.get().getName() + "-" + taskResource.getName())
                     .vpcId(taskSubnetMap.get(taskResource.getName()).getVpcId())
                     .subnetId(taskSubnetMap.get(taskResource.getName()).getSubnetId())
                     .accountId(cluster.getAccount())
@@ -107,7 +108,8 @@ public class ECSTaskUtil {
         } else {
             labelsBuilder = Labels.builder()
                     .workload(taskDefResource.getName())
-                    .taskId(taskDefResource.getName() + "-" + taskResource.getName())
+                    .taskId(taskResource.getName())
+                    .pod(taskDefResource.getName() + "-" + taskResource.getName())
                     .vpcId(taskSubnetMap.get(taskResource.getName()).getVpcId())
                     .subnetId(taskSubnetMap.get(taskResource.getName()).getSubnetId())
                     .accountId(cluster.getAccount())

--- a/src/main/java/ai/asserts/aws/exporter/Labels.java
+++ b/src/main/java/ai/asserts/aws/exporter/Labels.java
@@ -29,8 +29,10 @@ public class Labels extends TreeMap<String, String> {
     private String taskDefVersion;
     @JsonProperty
     private String container;
-    @JsonProperty("pod")
+    @JsonProperty("task_id")
     private String taskId;
+    @JsonProperty("pod")
+    private String pod;
 
     private String vpcId;
     private String subnetId;
@@ -71,7 +73,10 @@ public class Labels extends TreeMap<String, String> {
             put("container", container);
         }
         if (taskId != null) {
-            put("pod", taskId);
+            put("task_id", taskId);
+        }
+        if (pod != null) {
+            put("pod", pod);
         }
         if (isNotEmpty(vpcId)) {
             put("vpc_id", vpcId);

--- a/src/test/java/ai/asserts/aws/exporter/ECSTaskUtilTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSTaskUtilTest.java
@@ -181,7 +181,7 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                 () -> assertEquals("model-builder", staticConfig.getLabels().getJob()),
                 () -> assertEquals("task-def", staticConfig.getLabels().getTaskDefName()),
                 () -> assertEquals("5", staticConfig.getLabels().getTaskDefVersion()),
-                () -> assertEquals("service-task-id", staticConfig.getLabels().getTaskId()),
+                () -> assertEquals("service-task-id", staticConfig.getLabels().getPod()),
                 () -> assertEquals("/metric/path", staticConfig.getLabels().getMetricsPath()),
                 () -> assertEquals("model-builder", staticConfig.getLabels().getContainer()),
                 () -> assertEquals("vpc-id", staticConfig.getLabels().getVpcId()),
@@ -256,14 +256,14 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                 () -> assertEquals("cluster", staticConfigs.get(0).getLabels().getCluster()),
                 () -> assertEquals("task-def", staticConfigs.get(0).getLabels().getTaskDefName()),
                 () -> assertEquals("5", staticConfigs.get(0).getLabels().getTaskDefVersion()),
-                () -> assertEquals("service-task-id", staticConfigs.get(0).getLabels().getTaskId()),
+                () -> assertEquals("service-task-id", staticConfigs.get(0).getLabels().getPod()),
                 () -> assertEquals("/metrics", staticConfigs.get(0).getLabels().getMetricsPath()),
                 () -> assertEquals("vpc-id", staticConfigs.get(0).getLabels().getVpcId()),
 
                 () -> assertEquals("cluster", staticConfigs.get(1).getLabels().getCluster()),
                 () -> assertEquals("task-def", staticConfigs.get(1).getLabels().getTaskDefName()),
                 () -> assertEquals("5", staticConfigs.get(1).getLabels().getTaskDefVersion()),
-                () -> assertEquals("service-task-id", staticConfigs.get(1).getLabels().getTaskId()),
+                () -> assertEquals("service-task-id", staticConfigs.get(1).getLabels().getPod()),
                 () -> assertEquals("/metrics", staticConfigs.get(1).getLabels().getMetricsPath()),
                 () -> assertEquals("vpc-id", staticConfigs.get(0).getLabels().getVpcId()),
                 () -> assertEquals(ImmutableSet.of("api-server", "model-builder"), staticConfigs.stream()
@@ -355,13 +355,13 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                 () -> assertEquals("cluster", staticConfigs.get(0).getLabels().getCluster()),
                 () -> assertEquals("task-def", staticConfigs.get(0).getLabels().getTaskDefName()),
                 () -> assertEquals("5", staticConfigs.get(0).getLabels().getTaskDefVersion()),
-                () -> assertEquals("service-task-id", staticConfigs.get(0).getLabels().getTaskId()),
+                () -> assertEquals("service-task-id", staticConfigs.get(0).getLabels().getPod()),
                 () -> assertEquals("vpc-id", staticConfigs.get(0).getLabels().getVpcId()),
 
                 () -> assertEquals("cluster", staticConfigs.get(1).getLabels().getCluster()),
                 () -> assertEquals("task-def", staticConfigs.get(1).getLabels().getTaskDefName()),
                 () -> assertEquals("5", staticConfigs.get(1).getLabels().getTaskDefVersion()),
-                () -> assertEquals("service-task-id", staticConfigs.get(1).getLabels().getTaskId()),
+                () -> assertEquals("service-task-id", staticConfigs.get(1).getLabels().getPod()),
                 () -> assertEquals("vpc-id", staticConfigs.get(0).getLabels().getVpcId()),
                 () -> assertEquals(ImmutableSet.of("api-server", "model-builder"), staticConfigs.stream()
                         .map(sc -> sc.getLabels().getJob())
@@ -481,7 +481,7 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                 () -> assertEquals("api-server", apiServer_8081.get().getLabels().getJob()),
                 () -> assertEquals("task-def", apiServer_8081.get().getLabels().getTaskDefName()),
                 () -> assertEquals("5", apiServer_8081.get().getLabels().getTaskDefVersion()),
-                () -> assertEquals("service-task-id", apiServer_8081.get().getLabels().getTaskId()),
+                () -> assertEquals("service-task-id", apiServer_8081.get().getLabels().getPod()),
                 () -> assertEquals("/prometheus/metrics", apiServer_8081.get().getLabels().getMetricsPath())
         );
         assertAll(
@@ -490,7 +490,7 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                 () -> assertEquals("api-server", apiServer_8082.get().getLabels().getJob()),
                 () -> assertEquals("task-def", apiServer_8082.get().getLabels().getTaskDefName()),
                 () -> assertEquals("5", apiServer_8082.get().getLabels().getTaskDefVersion()),
-                () -> assertEquals("service-task-id", apiServer_8082.get().getLabels().getTaskId()),
+                () -> assertEquals("service-task-id", apiServer_8082.get().getLabels().getPod()),
                 () -> assertEquals("/metrics", apiServer_8082.get().getLabels().getMetricsPath())
         );
         assertAll(
@@ -499,7 +499,7 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                 () -> assertEquals("model-builder", modelBuilder.get().getLabels().getJob()),
                 () -> assertEquals("task-def", modelBuilder.get().getLabels().getTaskDefName()),
                 () -> assertEquals("5", modelBuilder.get().getLabels().getTaskDefVersion()),
-                () -> assertEquals("service-task-id", modelBuilder.get().getLabels().getTaskId()),
+                () -> assertEquals("service-task-id", modelBuilder.get().getLabels().getPod()),
                 () -> assertEquals("/metrics", modelBuilder.get().getLabels().getMetricsPath())
         );
         verifyAll();
@@ -574,7 +574,7 @@ public class ECSTaskUtilTest extends EasyMockSupport {
                 () -> assertEquals("api-server", staticConfigs.get(0).getLabels().getJob()),
                 () -> assertEquals("task-def", staticConfigs.get(0).getLabels().getTaskDefName()),
                 () -> assertEquals("5", staticConfigs.get(0).getLabels().getTaskDefVersion()),
-                () -> assertEquals("service-task-id", staticConfigs.get(0).getLabels().getTaskId()),
+                () -> assertEquals("service-task-id", staticConfigs.get(0).getLabels().getPod()),
                 () -> assertEquals("/prometheus/metrics", staticConfigs.get(0).getLabels().getMetricsPath()),
                 () -> assertEquals("api-server", staticConfigs.get(0).getLabels().getContainer()),
                 () -> assertEquals(ImmutableSet.of("10.20.30.40:52342"),


### PR DESCRIPTION
[ch14584]

```
# HELP aws_ecs_task_info 
# TYPE aws_ecs_task_info gauge
aws_ecs_task_info{account_id="342994379019",asserts_env="dev",asserts_site="dev",cluster="asserts-aws-integration",region="us-west-2",service="exporter",task_id="daacc6fa3ffb4912aa737b23e40dc0dc",taskdef_family="asserts-aws-integration",taskdef_version="5",} 1.0
aws_ecs_task_info{account_id="342994379019",asserts_env="dev",asserts_site="dev",cluster="workload-generator",region="us-west-2",service="load-generator",task_id="01adfe39cd144d3fb68d9e4bb7e7b8f8",taskdef_family="workload-generator",taskdef_version="4",} 1.0
```