### PR TITLE
Support Multiple AWS Exporters in same AWS Account Region

### DIFF
--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -129,7 +129,6 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
         this.resourceTagHelper = resourceTagHelper;
         this.tagUtil = tagUtil;
 
-
         identifySubnetsToScrape();
     }
 

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -49,6 +49,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -77,6 +78,7 @@ import static org.springframework.util.StringUtils.hasLength;
 @Component
 public class ECSServiceDiscoveryExporter extends Collector implements MetricProvider, InitializingBean {
     public static final String ECS_CONTAINER_METADATA_URI_V4 = "ECS_CONTAINER_METADATA_URI_V4";
+    public static final String SCRAPE_ECS_SUBNETS = "SCRAPE_ECS_SUBNETS";
     private final RestTemplate restTemplate;
     private final AccountProvider accountProvider;
     private final ScrapeConfigProvider scrapeConfigProvider;
@@ -94,6 +96,8 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
     @Getter
     private final AtomicReference<SubnetDetails> subnetDetails = new AtomicReference<>(null);
 
+    protected final Set<String> subnetsToScrape = new TreeSet<>();
+
     @Getter
     private volatile List<StaticConfig> targets = new ArrayList<>();
 
@@ -102,6 +106,8 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
 
     @Getter
     private volatile List<MetricFamilySamples> taskMetaMetric = new ArrayList<>();
+
+
 
     public ECSServiceDiscoveryExporter(RestTemplate restTemplate, AccountProvider accountProvider,
                                        ScrapeConfigProvider scrapeConfigProvider,
@@ -122,6 +128,19 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
         this.metricSampleBuilder = metricSampleBuilder;
         this.resourceTagHelper = resourceTagHelper;
         this.tagUtil = tagUtil;
+
+
+        identifySubnetsToScrape();
+    }
+
+    @VisibleForTesting
+    void identifySubnetsToScrape() {
+        if (System.getenv(SCRAPE_ECS_SUBNETS) != null) {
+            this.subnetsToScrape.addAll(
+                    Arrays.stream(System.getenv(SCRAPE_ECS_SUBNETS).split(","))
+                            .map(String::trim)
+                            .collect(Collectors.toSet()));
+        }
     }
 
     @Override
@@ -247,12 +266,17 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
         }
     }
 
-    private boolean shouldScrapeTargets(ScrapeConfig scrapeConfig, StaticConfig config) {
+    @VisibleForTesting
+    boolean shouldScrapeTargets(ScrapeConfig scrapeConfig, StaticConfig config) {
+        String targetVpc = config.getLabels().getVpcId();
+        String targetSubnet = config.getLabels().getSubnetId();
         boolean vpcOK = scrapeConfig.isDiscoverECSTasksAcrossVPCs() ||
-                (subnetDetails.get() != null && subnetDetails.get().getVpcId().equals(config.getLabels().getVpcId()));
-        boolean subnetOK = !scrapeConfig.isDiscoverOnlySubnetTasks() ||
-                (subnetDetails.get() != null && subnetDetails.get().getSubnetId()
-                        .equals(config.getLabels().getSubnetId()));
+                (subnetDetails.get() != null && subnetDetails.get().getVpcId().equals(targetVpc));
+        boolean subnetOK = subnetsToScrape.contains(targetSubnet) ||
+                (subnetDetails.get() != null && (
+                        subnetDetails.get().getSubnetId().equals(targetSubnet) ||
+                                subnetsToScrape.contains(targetSubnet)
+                )) || !scrapeConfig.isDiscoverOnlySubnetTasks();
         return vpcOK && subnetOK;
     }
 

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -273,10 +273,8 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
         boolean vpcOK = scrapeConfig.isDiscoverECSTasksAcrossVPCs() ||
                 (subnetDetails.get() != null && subnetDetails.get().getVpcId().equals(targetVpc));
         boolean subnetOK = subnetsToScrape.contains(targetSubnet) ||
-                (subnetDetails.get() != null && (
-                        subnetDetails.get().getSubnetId().equals(targetSubnet) ||
-                                subnetsToScrape.contains(targetSubnet)
-                )) || !scrapeConfig.isDiscoverOnlySubnetTasks();
+                (subnetDetails.get() != null && subnetDetails.get().getSubnetId().equals(targetSubnet)) ||
+                !scrapeConfig.isDiscoverOnlySubnetTasks();
         return vpcOK && subnetOK;
     }
 

--- a/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
@@ -48,6 +48,7 @@ import static java.lang.String.format;
 @Component
 @Slf4j
 public class ECSTaskUtil {
+    public static final String INSTALLED_ENV_NAME = "INSTALL_ENV_NAME";
     private final AWSClientProvider awsClientProvider;
     private final ResourceMapper resourceMapper;
     private final RateLimiter rateLimiter;
@@ -73,7 +74,6 @@ public class ECSTaskUtil {
     @VisibleForTesting
     String getInstallEnvName() {
         final String envName;
-        String INSTALLED_ENV_NAME = "INSTALL_ENV_NAME";
         if (System.getenv(INSTALLED_ENV_NAME) != null) {
             envName = System.getenv(INSTALLED_ENV_NAME);
         } else {

--- a/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
@@ -14,8 +14,8 @@ import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
 import ai.asserts.aws.exporter.Labels.LabelsBuilder;
 import ai.asserts.aws.resource.Resource;
 import ai.asserts.aws.resource.ResourceMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSortedMap;
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.ec2.Ec2Client;
@@ -47,11 +47,12 @@ import static java.lang.String.format;
 
 @Component
 @Slf4j
-@AllArgsConstructor
 public class ECSTaskUtil {
     private final AWSClientProvider awsClientProvider;
     private final ResourceMapper resourceMapper;
     private final RateLimiter rateLimiter;
+
+    private final String envName;
 
     private final Map<String, String> subnetIdMap = new ConcurrentHashMap<>();
     private final Map<String, SubnetDetails> taskSubnetMap = new ConcurrentHashMap<>();
@@ -61,6 +62,25 @@ public class ECSTaskUtil {
     public static final String PROMETHEUS_PORT_DOCKER_LABEL = "PROMETHEUS_EXPORTER_PORT";
     public static final String PROMETHEUS_METRIC_PATH_DOCKER_LABEL = "PROMETHEUS_EXPORTER_PATH";
 
+    public ECSTaskUtil(AWSClientProvider awsClientProvider, ResourceMapper resourceMapper, RateLimiter rateLimiter) {
+        this.awsClientProvider = awsClientProvider;
+        this.resourceMapper = resourceMapper;
+        this.rateLimiter = rateLimiter;
+        // If the exporter's environment name is marked, use this for ECS metrics
+        envName = getInstallEnvName();
+    }
+
+    @VisibleForTesting
+    String getInstallEnvName() {
+        final String envName;
+        String INSTALLED_ENV_NAME = "INSTALL_ENV_NAME";
+        if (System.getenv(INSTALLED_ENV_NAME) != null) {
+            envName = System.getenv(INSTALLED_ENV_NAME);
+        } else {
+            envName = null;
+        }
+        return envName;
+    }
 
     public boolean hasAllInfo(Task task) {
         return "RUNNING".equals(task.lastStatus()) && task.hasAttachments() && task.attachments()
@@ -100,7 +120,7 @@ public class ECSTaskUtil {
                     .accountId(cluster.getAccount())
                     .region(cluster.getRegion())
                     .cluster(cluster.getName())
-                    .env(cluster.getAccount())
+                    .env(envName != null ? envName : cluster.getAccount())
                     .site(cluster.getRegion())
                     .taskDefName(taskDefResource.getName())
                     .taskDefVersion(taskDefResource.getVersion())
@@ -115,7 +135,7 @@ public class ECSTaskUtil {
                     .accountId(cluster.getAccount())
                     .region(cluster.getRegion())
                     .cluster(cluster.getName())
-                    .env(cluster.getAccount())
+                    .env(envName != null ? envName : cluster.getAccount())
                     .site(cluster.getRegion())
                     .taskDefName(taskDefResource.getName())
                     .taskDefVersion(taskDefResource.getVersion())


### PR DESCRIPTION
[ch15100]

The `INSTALL_ENV_NAME` and `SCRAPE_ECS_SUBNETS` will be set by the installer. See https://github.com/asserts/downloads/pull/32