### PR TITLE
Add diagnostic logs for AWS rate limit error

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-awsSdkVersion=2.19.8
+awsSdkVersion=2.20.3
 easyMockVersion=4.2
 guavaVersion=28.1-jre
 jacksonVersion=2.10.2

--- a/src/main/java/ai/asserts/aws/RateLimiter.java
+++ b/src/main/java/ai/asserts/aws/RateLimiter.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Semaphore;
 import static ai.asserts.aws.MetricNameUtil.ASSERTS_ERROR_TYPE;
 import static ai.asserts.aws.MetricNameUtil.SCRAPE_ERROR_COUNT_METRIC;
 import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
 
 @Component
 @Slf4j
@@ -31,6 +32,8 @@ import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
 public class RateLimiter {
     private final Semaphore defaultSemaphore = new Semaphore(2);
     private final BasicMetricCollector metricCollector;
+
+    private final ThreadLocal<Map<String, Integer>> apiCallCounts = ThreadLocal.withInitial(TreeMap::new);
 
     private final Map<String, Semaphore> semaphores = new ImmutableMap.Builder<String, Semaphore>()
             .put(LambdaClient.class.getSimpleName(), new Semaphore(2))
@@ -46,10 +49,15 @@ public class RateLimiter {
         long tick = System.currentTimeMillis();
         try {
             theSemaphore.acquire();
+            Map<String, Integer> callCounts = apiCallCounts.get();
+            Integer count = callCounts.getOrDefault(labels.get(SCRAPE_OPERATION_LABEL), 0);
+            count++;
+            callCounts.put(labels.get(SCRAPE_OPERATION_LABEL), count);
             tick = System.currentTimeMillis();
             return k.makeCall();
         } catch (Throwable e) {
             log.error("Exception", e);
+            log.info("AWS API Call Counts {}", apiCallCounts.get());
             SortedMap<String, String> errorLabels = new TreeMap<>(labels);
             errorLabels.put(ASSERTS_ERROR_TYPE, e.getClass().getSimpleName());
             metricCollector.recordCounterValue(SCRAPE_ERROR_COUNT_METRIC, errorLabels, 1);
@@ -58,6 +66,16 @@ public class RateLimiter {
             tick = System.currentTimeMillis() - tick;
             metricCollector.recordLatency(SCRAPE_LATENCY_METRIC, labels, tick);
             theSemaphore.release();
+        }
+    }
+
+    public void runTask(Runnable runnable) {
+        try {
+            runnable.run();
+        } finally {
+            Map<String, Integer> callCounts = apiCallCounts.get();
+            log.info("AWS API Call Counts {}", callCounts);
+            callCounts.clear();
         }
     }
 

--- a/src/main/java/ai/asserts/aws/RateLimiter.java
+++ b/src/main/java/ai/asserts/aws/RateLimiter.java
@@ -50,9 +50,10 @@ public class RateLimiter {
         try {
             theSemaphore.acquire();
             Map<String, Integer> callCounts = apiCallCounts.get();
-            Integer count = callCounts.getOrDefault(labels.get(SCRAPE_OPERATION_LABEL), 0);
+            String operationName = labels.getOrDefault(SCRAPE_OPERATION_LABEL, "unknown");
+            Integer count = callCounts.getOrDefault(operationName, 0);
             count++;
-            callCounts.put(labels.get(SCRAPE_OPERATION_LABEL), count);
+            callCounts.put(operationName, count);
             tick = System.currentTimeMillis();
             return k.makeCall();
         } catch (Throwable e) {

--- a/src/main/java/ai/asserts/aws/cloudwatch/query/MetricQueryProvider.java
+++ b/src/main/java/ai/asserts/aws/cloudwatch/query/MetricQueryProvider.java
@@ -115,7 +115,7 @@ public class MetricQueryProvider {
 
                                     ListMetricsRequest request = builder.build();
                                     ListMetricsResponse response = rateLimiter.doWithRateLimit(
-                                            "CloudWatchClient/listMetrics",
+                                            "CloudWatchClient/ListMetrics",
                                             operationLabels(account, region, ns),
                                             () -> cloudWatchClient.listMetrics(request));
 
@@ -165,7 +165,7 @@ public class MetricQueryProvider {
         return ImmutableSortedMap.of(
                 SCRAPE_ACCOUNT_ID_LABEL, account,
                 SCRAPE_REGION_LABEL, region,
-                SCRAPE_OPERATION_LABEL, "list_metrics",
+                SCRAPE_OPERATION_LABEL, "CloudWatchClient/ListMetrics",
                 SCRAPE_NAMESPACE_LABEL, ns.getName()
         );
     }

--- a/src/main/java/ai/asserts/aws/exporter/ApiGatewayToLambdaBuilder.java
+++ b/src/main/java/ai/asserts/aws/exporter/ApiGatewayToLambdaBuilder.java
@@ -101,7 +101,7 @@ public class ApiGatewayToLambdaBuilder extends Collector
                                 rateLimiter.doWithRateLimit(getRestApis, labels, client::getRestApis);
                         if (restApis.hasItems()) {
                             restApis.items().forEach(restApi -> {
-                                String getResources = "getResources";
+                                String getResources = "ResourceGroupsTaggingApiClient/getResources";
                                 labels.put(SCRAPE_OPERATION_LABEL, getResources);
                                 GetResourcesResponse resources = rateLimiter.doWithRateLimit(getResources, labels,
                                         () -> client.getResources(GetResourcesRequest.builder()

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -335,11 +335,12 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
             ListTasksRequest tasksRequest = ListTasksRequest.builder()
                     .cluster(cluster.getName())
                     .build();
-            ListTasksResponse tasksResponse = rateLimiter.doWithRateLimit("EcsClient/listTasks",
+            String operationName = "EcsClient/listTasks";
+            ListTasksResponse tasksResponse = rateLimiter.doWithRateLimit(operationName,
                     ImmutableSortedMap.of(
                             SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(),
                             SCRAPE_REGION_LABEL, cluster.getRegion(),
-                            SCRAPE_OPERATION_LABEL, "listTasks",
+                            SCRAPE_OPERATION_LABEL, operationName,
                             SCRAPE_NAMESPACE_LABEL, "AWS/ECS"),
                     () -> ecsClient.listTasks(tasksRequest));
             if (tasksResponse.hasTaskArns()) {
@@ -381,9 +382,10 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
                     .cluster(cluster.getName())
                     .serviceName(service.getName())
                     .nextToken(nextToken).build();
-            ListTasksResponse tasksResp = rateLimiter.doWithRateLimit("EcsClient/listTasks",
+            String operationName = "EcsClient/listTasks";
+            ListTasksResponse tasksResp = rateLimiter.doWithRateLimit(operationName,
                     ImmutableSortedMap.of(SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(), SCRAPE_REGION_LABEL,
-                            cluster.getRegion(), SCRAPE_OPERATION_LABEL, "listTasks", SCRAPE_NAMESPACE_LABEL,
+                            cluster.getRegion(), SCRAPE_OPERATION_LABEL, operationName, SCRAPE_NAMESPACE_LABEL,
                             "AWS/ECS"), () -> ecsClient.listTasks(request));
 
             nextToken = tasksResp.nextToken();

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -109,7 +109,6 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
     private volatile List<MetricFamilySamples> taskMetaMetric = new ArrayList<>();
 
 
-
     public ECSServiceDiscoveryExporter(RestTemplate restTemplate, AccountProvider accountProvider,
                                        ScrapeConfigProvider scrapeConfigProvider,
                                        AWSClientProvider awsClientProvider, ResourceMapper resourceMapper,
@@ -205,27 +204,27 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
         log.info("Discovering ECS targets with scrape configs={}", scrapeConfig.getEcsTaskScrapeConfigs());
         try {
             accountProvider.getAccounts().forEach(awsAccount -> awsAccount.getRegions().forEach(region -> {
+                String operationName = "EcsClient/listClusters";
                 ImmutableSortedMap<String, String> TELEMETRY_LABELS =
                         ImmutableSortedMap.of(
                                 SCRAPE_ACCOUNT_ID_LABEL, awsAccount.getAccountId(),
                                 SCRAPE_REGION_LABEL, region,
-                                SCRAPE_OPERATION_LABEL, "listClusters",
+                                SCRAPE_OPERATION_LABEL, operationName,
                                 SCRAPE_NAMESPACE_LABEL, "AWS/ECS");
                 SortedMap<String, String> labels = new TreeMap<>(TELEMETRY_LABELS);
                 try {
                     EcsClient ecsClient = awsClientProvider.getECSClient(region, awsAccount);
                     // List clusters just returns the cluster ARN. There is no need to paginate
-                    ListClustersResponse listClustersResponse = rateLimiter.doWithRateLimit("EcsClient/listClusters",
-                            ImmutableSortedMap.of(
-                                    SCRAPE_ACCOUNT_ID_LABEL, awsAccount.getAccountId(),
-                                    SCRAPE_REGION_LABEL, region,
-                                    SCRAPE_OPERATION_LABEL, "listClusters",
-                                    SCRAPE_NAMESPACE_LABEL, "AWS/ECS"),
+                    ListClustersResponse listClustersResponse = rateLimiter.doWithRateLimit(operationName,
+                            TELEMETRY_LABELS,
                             ecsClient::listClusters);
                     labels.put(SCRAPE_REGION_LABEL, region);
                     if (listClustersResponse.hasClusterArns()) {
-                        listClustersResponse.clusterArns().stream().map(resourceMapper::map).filter(Optional::isPresent)
-                                .map(Optional::get).forEach(cluster -> latestTargets.addAll(
+                        listClustersResponse.clusterArns().stream()
+                                .map(resourceMapper::map)
+                                .filter(Optional::isPresent)
+                                .map(Optional::get)
+                                .forEach(cluster -> latestTargets.addAll(
                                         buildTargetsInCluster(awsAccount, scrapeConfig, ecsClient, cluster, newRouting,
                                                 taskMetaMetricSamples)));
                     }
@@ -291,11 +290,12 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
             ListServicesRequest serviceReq = ListServicesRequest.builder()
                     .cluster(cluster.getName())
                     .build();
-            ListServicesResponse serviceResp = rateLimiter.doWithRateLimit("EcsClient/listServices",
+            String operationName = "EcsClient/listServices";
+            ListServicesResponse serviceResp = rateLimiter.doWithRateLimit(operationName,
                     ImmutableSortedMap.of(
                             SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(),
                             SCRAPE_REGION_LABEL, cluster.getRegion(),
-                            SCRAPE_OPERATION_LABEL, "listServices",
+                            SCRAPE_OPERATION_LABEL, operationName,
                             SCRAPE_NAMESPACE_LABEL, "AWS/ECS"),
                     () -> ecsClient.listServices(serviceReq));
             if (serviceResp.hasServiceArns()) {
@@ -412,16 +412,16 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
     List<StaticConfig> buildTaskTargets(ScrapeConfig scrapeConfig, EcsClient ecsClient, Resource cluster,
                                         Optional<Resource> service, Set<String> taskARNs,
                                         Map<String, String> tagLabels, List<Sample> taskMetaMetric) {
-        service.ifPresent(serviceRes -> {
-            log.info("Building ECS targets in cluster={}, service={}", cluster.getName(), serviceRes.getName());
-        });
+        service.ifPresent(serviceRes ->
+                log.info("Building ECS targets in cluster={}, service={}", cluster.getName(), serviceRes.getName()));
 
         List<StaticConfig> configs = new ArrayList<>();
         DescribeTasksRequest request =
                 DescribeTasksRequest.builder().cluster(cluster.getName()).tasks(taskARNs).build();
-        DescribeTasksResponse taskResponse = rateLimiter.doWithRateLimit("EcsClient/describeTasks",
+        String operationName = "EcsClient/describeTasks";
+        DescribeTasksResponse taskResponse = rateLimiter.doWithRateLimit(operationName,
                 ImmutableSortedMap.of(SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(), SCRAPE_REGION_LABEL,
-                        cluster.getRegion(), SCRAPE_OPERATION_LABEL, "describeTasks", SCRAPE_NAMESPACE_LABEL,
+                        cluster.getRegion(), SCRAPE_OPERATION_LABEL, operationName, SCRAPE_NAMESPACE_LABEL,
                         "AWS/ECS"), () -> ecsClient.describeTasks(request));
         if (taskResponse.hasTasks()) {
             configs.addAll(taskResponse.tasks().stream()

--- a/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
@@ -155,11 +155,12 @@ public class ECSTaskUtil {
         }
 
         try {
-            TaskDefinition taskDefinition = rateLimiter.doWithRateLimit("EcsClient/describeTaskDefinition",
+            String operationName = "EcsClient/describeTaskDefinition";
+            TaskDefinition taskDefinition = rateLimiter.doWithRateLimit(operationName,
                     ImmutableSortedMap.of(
                             SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(),
                             SCRAPE_REGION_LABEL, cluster.getRegion(),
-                            SCRAPE_OPERATION_LABEL, "describeTaskDefinition",
+                            SCRAPE_OPERATION_LABEL, operationName,
                             SCRAPE_NAMESPACE_LABEL, "AWS/ECS"
                     ), () ->
                             ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()

--- a/src/main/java/ai/asserts/aws/exporter/MetricScrapeTask.java
+++ b/src/main/java/ai/asserts/aws/exporter/MetricScrapeTask.java
@@ -155,12 +155,13 @@ public class MetricScrapeTask extends Collector implements MetricProvider {
                                     .collect(Collectors.toList()));
 
                     GetMetricDataRequest req = requestBuilder.build();
+                    String operationName = "CloudWatchClient/getMetricData";
                     GetMetricDataResponse metricData = rateLimiter.doWithRateLimit(
-                            "CloudWatchClient/getMetricData",
+                            operationName,
                             ImmutableSortedMap.of(
                                     SCRAPE_ACCOUNT_ID_LABEL, account.getAccountId(),
                                     SCRAPE_REGION_LABEL, region,
-                                    SCRAPE_OPERATION_LABEL, "getMetricData",
+                                    SCRAPE_OPERATION_LABEL, operationName,
                                     SCRAPE_INTERVAL_LABEL, intervalSeconds + ""
                             ),
                             () -> cloudWatchClient.getMetricData(req));

--- a/src/main/java/ai/asserts/aws/lambda/LambdaFunctionScraper.java
+++ b/src/main/java/ai/asserts/aws/lambda/LambdaFunctionScraper.java
@@ -92,6 +92,7 @@ public class LambdaFunctionScraper extends Collector implements MetricProvider {
 
     @Override
     public void update() {
+        log.info("Discover Lambda functions");
         try {
             Map<String, Map<String, Map<String, LambdaFunction>>> byAccount = getFunctions();
             List<Sample> samples = new ArrayList<>();

--- a/src/main/java/ai/asserts/aws/resource/ResourceTagHelper.java
+++ b/src/main/java/ai/asserts/aws/resource/ResourceTagHelper.java
@@ -141,7 +141,7 @@ public class ResourceTagHelper {
             ImmutableSortedMap<String, String> labels = ImmutableSortedMap.of(
                     SCRAPE_REGION_LABEL, key.region,
                     SCRAPE_NAMESPACE_LABEL, key.namespace.getName(),
-                    SCRAPE_OPERATION_LABEL, "getResources"
+                    SCRAPE_OPERATION_LABEL, "ResourceGroupsTaggingApiClient/getResources"
             );
             resources.addAll(getResourcesWithTag(key.accountRegion, key.region, labels, builder));
             log.info("Found {}", resources.stream()

--- a/src/test/java/ai/asserts/aws/MetadataTaskManagerTest.java
+++ b/src/test/java/ai/asserts/aws/MetadataTaskManagerTest.java
@@ -116,7 +116,7 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
                 apiGatewayToLambdaBuilder, kinesisAnalyticsExporter, kinesisFirehoseExporter,
                 s3BucketExporter, taskThreadPool, scrapeConfigProvider, ecsServiceDiscoveryExporter, redshiftExporter,
                 sqsQueueExporter, kinesisStreamExporter, loadBalancerExporter, rdsExporter, dynamoDBExporter,
-                snsTopicExporter, emrExporter);
+                snsTopicExporter, emrExporter, new RateLimiter(metricCollector));
     }
 
     @Test

--- a/src/test/java/ai/asserts/aws/MetricTaskManagerTest.java
+++ b/src/test/java/ai/asserts/aws/MetricTaskManagerTest.java
@@ -3,6 +3,7 @@ package ai.asserts.aws;
 import ai.asserts.aws.cloudwatch.alarms.AlarmFetcher;
 import ai.asserts.aws.cloudwatch.alarms.AlarmMetricExporter;
 import ai.asserts.aws.config.ScrapeConfig;
+import ai.asserts.aws.exporter.BasicMetricCollector;
 import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter;
 import ai.asserts.aws.exporter.MetricScrapeTask;
 import com.google.common.collect.ImmutableMap;
@@ -32,6 +33,7 @@ public class MetricTaskManagerTest extends EasyMockSupport {
     private ExecutorService executorService;
     private AlarmMetricExporter alarmMetricExporter;
     private AlarmFetcher alarmFetcher;
+    private BasicMetricCollector metricCollector;
 
     private ECSServiceDiscoveryExporter ecsServiceDiscoveryExporter;
 
@@ -48,10 +50,11 @@ public class MetricTaskManagerTest extends EasyMockSupport {
         alarmMetricExporter = mock(AlarmMetricExporter.class);
         alarmFetcher = mock(AlarmFetcher.class);
         ecsServiceDiscoveryExporter = mock(ECSServiceDiscoveryExporter.class);
-
+        metricCollector = mock(BasicMetricCollector.class);
         replayAll();
         testClass = new MetricTaskManager(accountProvider, scrapeConfigProvider, collectorRegistry, beanFactory,
-                taskThreadPool, alarmMetricExporter, alarmFetcher, ecsServiceDiscoveryExporter);
+                taskThreadPool, alarmMetricExporter, alarmFetcher, ecsServiceDiscoveryExporter
+                , new RateLimiter(metricCollector));
         verifyAll();
         resetAll();
     }
@@ -69,7 +72,8 @@ public class MetricTaskManagerTest extends EasyMockSupport {
     @Test
     void triggerScrapes() {
         testClass = new MetricTaskManager(accountProvider, scrapeConfigProvider, collectorRegistry, beanFactory,
-                taskThreadPool, alarmMetricExporter, alarmFetcher, ecsServiceDiscoveryExporter) {
+                taskThreadPool, alarmMetricExporter, alarmFetcher, ecsServiceDiscoveryExporter,
+                new RateLimiter(metricCollector)) {
             @Override
             void updateScrapeTasks() {
             }


### PR DESCRIPTION
[ch15126]

```
INFO  2023-03-14 17:13:12.524 pool-1-thread-6 RateLimiter AWS API Call Counts {EcsClient/describeServices=2, EcsClient/describeTaskDefinition=1, EcsClient/describeTasks=1, EcsClient/listClusters=1, EcsClient/listServices=2, ResourceGroupsTaggingApiClient/getResources=2, listTasks=4}
```