### PR TITLE
Refactor ECS Service Discovery

### DIFF
--- a/src/main/java/ai/asserts/aws/MetadataTaskManager.java
+++ b/src/main/java/ai/asserts/aws/MetadataTaskManager.java
@@ -10,6 +10,7 @@ import ai.asserts.aws.exporter.KinesisAnalyticsExporter;
 import ai.asserts.aws.exporter.KinesisFirehoseExporter;
 import ai.asserts.aws.exporter.KinesisStreamExporter;
 import ai.asserts.aws.exporter.LBToASGRelationBuilder;
+import ai.asserts.aws.exporter.LBToECSRoutingBuilder;
 import ai.asserts.aws.exporter.LambdaCapacityExporter;
 import ai.asserts.aws.exporter.LambdaEventSourceExporter;
 import ai.asserts.aws.exporter.LambdaInvokeConfigExporter;
@@ -50,6 +51,7 @@ public class MetadataTaskManager implements InitializingBean {
     private final TargetGroupLBMapProvider targetGroupLBMapProvider;
     private final ResourceRelationExporter relationExporter;
     private final LBToASGRelationBuilder lbToASGRelationBuilder;
+    private final LBToECSRoutingBuilder lbToECSRoutingBuilder;
     private final EC2ToEBSVolumeExporter ec2ToEBSVolumeExporter;
     private final ApiGatewayToLambdaBuilder apiGatewayToLambdaBuilder;
     private final KinesisAnalyticsExporter kinesisAnalyticsExporter;
@@ -108,6 +110,7 @@ public class MetadataTaskManager implements InitializingBean {
         taskThreadPool.getExecutorService().submit(() -> rateLimiter.runTask(lambdaInvokeConfigExporter::update));
         taskThreadPool.getExecutorService().submit(() -> rateLimiter.runTask(targetGroupLBMapProvider::update));
         taskThreadPool.getExecutorService().submit(() -> rateLimiter.runTask(lbToASGRelationBuilder::updateRouting));
+        taskThreadPool.getExecutorService().submit(() -> rateLimiter.runTask(lbToECSRoutingBuilder));
         taskThreadPool.getExecutorService().submit(() -> rateLimiter.runTask(relationExporter::update));
         taskThreadPool.getExecutorService().submit(() -> rateLimiter.runTask(ec2ToEBSVolumeExporter::update));
         taskThreadPool.getExecutorService().submit(() -> rateLimiter.runTask(apiGatewayToLambdaBuilder::update));

--- a/src/main/java/ai/asserts/aws/MetadataTaskManager.java
+++ b/src/main/java/ai/asserts/aws/MetadataTaskManager.java
@@ -73,7 +73,6 @@ public class MetadataTaskManager implements InitializingBean {
     private final List<LambdaLogMetricScrapeTask> logScrapeTasks = new ArrayList<>();
 
     public void afterPropertiesSet() {
-        ecsServiceDiscoveryExporter.register(collectorRegistry);
         if (ecsServiceDiscoveryExporter.isPrimaryExporter()) {
             lambdaFunctionScraper.register(collectorRegistry);
             lambdaCapacityExporter.register(collectorRegistry);
@@ -128,11 +127,11 @@ public class MetadataTaskManager implements InitializingBean {
     }
 
     @SuppressWarnings("unused")
-    @Scheduled(fixedRateString = "${aws.metadata.scrape.manager.task.fixedDelay:60000}",
+    @Scheduled(fixedRateString = "${aws.metadata.scrape.manager.task.fixedDelay:300000}",
             initialDelayString = "${aws.metadata.scrape.manager.task.initialDelay:5000}")
     @Timed(description = "Time spent scraping AWS Resource meta data from all regions", histogram = true)
     public void perMinute() {
         taskThreadPool.getExecutorService().submit(() -> rateLimiter.runTask(scrapeConfigProvider::update));
-        taskThreadPool.getExecutorService().submit(() -> rateLimiter.runTask(ecsServiceDiscoveryExporter::update));
+        taskThreadPool.getExecutorService().submit(() -> rateLimiter.runTask(ecsServiceDiscoveryExporter));
     }
 }

--- a/src/main/java/ai/asserts/aws/exporter/ECSClusterProvider.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSClusterProvider.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.AWSClientProvider;
+import ai.asserts.aws.AccountProvider.AWSAccount;
+import ai.asserts.aws.RateLimiter;
+import ai.asserts.aws.resource.Resource;
+import ai.asserts.aws.resource.ResourceMapper;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableSortedMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.DescribeClustersRequest;
+import software.amazon.awssdk.services.ecs.model.DescribeClustersResponse;
+import software.amazon.awssdk.services.ecs.model.ListClustersResponse;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_ACCOUNT_ID_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_NAMESPACE_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
+
+@Component
+@Slf4j
+public class ECSClusterProvider {
+    private final AWSClientProvider awsClientProvider;
+    private final RateLimiter rateLimiter;
+    private final ResourceMapper resourceMapper;
+    private final Map<String, Map<String, Supplier<Set<Resource>>>> clusterProviders = new ConcurrentHashMap<>();
+
+    public ECSClusterProvider(AWSClientProvider awsClientProvider, RateLimiter rateLimiter,
+                              ResourceMapper resourceMapper) {
+        this.awsClientProvider = awsClientProvider;
+        this.rateLimiter = rateLimiter;
+        this.resourceMapper = resourceMapper;
+    }
+
+    public Set<Resource> getClusters(AWSAccount account, String region) {
+        return clusterProviders
+                .computeIfAbsent(account.getAccountId(), k -> new ConcurrentHashMap<>())
+                .computeIfAbsent(region,
+                        k -> Suppliers.memoizeWithExpiration(() ->
+                                getClustersByRegion(account, k), 15, TimeUnit.MINUTES))
+                .get();
+    }
+
+    private Set<Resource> getClustersByRegion(AWSAccount awsAccount, String region) {
+        Set<Resource> clusters = new LinkedHashSet<>();
+        String operationName = "EcsClient/listClusters";
+        ImmutableSortedMap<String, String> TELEMETRY_LABELS =
+                ImmutableSortedMap.of(
+                        SCRAPE_ACCOUNT_ID_LABEL, awsAccount.getAccountId(),
+                        SCRAPE_REGION_LABEL, region,
+                        SCRAPE_OPERATION_LABEL, operationName,
+                        SCRAPE_NAMESPACE_LABEL, "AWS/ECS");
+        SortedMap<String, String> labels = new TreeMap<>(TELEMETRY_LABELS);
+
+        try {
+            Set<String> allClusterARNs = new TreeSet<>();
+            EcsClient ecsClient = awsClientProvider.getECSClient(region, awsAccount);
+            Paginator paginator = new Paginator();
+            do {
+                // List clusters just returns the cluster ARN. There is no need to paginate
+                ListClustersResponse listClustersResponse = rateLimiter.doWithRateLimit(operationName,
+                        labels,
+                        ecsClient::listClusters);
+                labels.put(SCRAPE_REGION_LABEL, region);
+                if (listClustersResponse.hasClusterArns()) {
+                    allClusterARNs.addAll(listClustersResponse.clusterArns());
+                }
+                paginator.nextToken(listClustersResponse.nextToken());
+            } while (paginator.hasNext());
+
+            log.info("Found {} total clusters : {}", allClusterARNs.size(), allClusterARNs);
+
+            // Filter by ACTIVE clusters
+            // List clusters just returns the cluster ARN. There is no need to paginate
+            operationName = "EcsClient/DescribeClusters";
+            labels.put(SCRAPE_OPERATION_LABEL, operationName);
+            DescribeClustersRequest describeClustersRequest = DescribeClustersRequest.builder()
+                    .clusters(allClusterARNs)
+                    .build();
+            DescribeClustersResponse listClustersResponse = rateLimiter.doWithRateLimit(operationName,
+                    labels,
+                    () -> ecsClient.describeClusters(describeClustersRequest));
+            if (listClustersResponse.hasClusters()) {
+                clusters.addAll(listClustersResponse.clusters().stream()
+                        .filter(cluster -> "ACTIVE".equals(cluster.status()))
+                        .map(cluster -> resourceMapper.map(cluster.clusterArn()))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .collect(Collectors.toSet()));
+            }
+        } catch (Exception e) {
+            log.error("Failed to get list of ECS Clusters", e);
+        }
+
+        log.info("Found {} ACTIVE clusters : {}", clusters.size(), clusters);
+        return clusters;
+    }
+}

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryController.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryController.java
@@ -4,7 +4,6 @@
  */
 package ai.asserts.aws.exporter;
 
-import ai.asserts.aws.ObjectMapperFactory;
 import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,14 +20,14 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
 @AllArgsConstructor
 @Slf4j
 public class ECSServiceDiscoveryController {
-    private final ECSServiceDiscoveryExporter ecsServiceDiscoveryExporter;
+    private final ECSTaskProvider ecsTaskProvider;
 
     @RequestMapping(
             path = "/ecs-sd-config",
             produces = {APPLICATION_JSON_VALUE},
             method = GET)
     public ResponseEntity<List<StaticConfig>> getECSSDConfig() {
-        List<StaticConfig> targets = ecsServiceDiscoveryExporter.getTargets();
+        List<StaticConfig> targets = ecsTaskProvider.getScrapeTargets();
         return ResponseEntity.ok(targets);
     }
 }

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -4,26 +4,16 @@
  */
 package ai.asserts.aws.exporter;
 
-import ai.asserts.aws.AWSClientProvider;
 import ai.asserts.aws.AccountProvider;
-import ai.asserts.aws.AccountProvider.AWSAccount;
 import ai.asserts.aws.ObjectMapperFactory;
-import ai.asserts.aws.RateLimiter;
 import ai.asserts.aws.ScrapeConfigProvider;
-import ai.asserts.aws.TagUtil;
 import ai.asserts.aws.config.ScrapeConfig;
 import ai.asserts.aws.config.ScrapeConfig.SubnetDetails;
-import ai.asserts.aws.resource.Resource;
 import ai.asserts.aws.resource.ResourceMapper;
-import ai.asserts.aws.resource.ResourceRelation;
-import ai.asserts.aws.resource.ResourceTagHelper;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSortedMap;
-import io.prometheus.client.Collector;
-import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -36,37 +26,18 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.client.RestTemplate;
-import software.amazon.awssdk.services.ecs.EcsClient;
-import software.amazon.awssdk.services.ecs.model.DescribeTasksRequest;
-import software.amazon.awssdk.services.ecs.model.DescribeTasksResponse;
-import software.amazon.awssdk.services.ecs.model.ListClustersResponse;
-import software.amazon.awssdk.services.ecs.model.ListServicesRequest;
-import software.amazon.awssdk.services.ecs.model.ListServicesResponse;
-import software.amazon.awssdk.services.ecs.model.ListTasksRequest;
-import software.amazon.awssdk.services.ecs.model.ListTasksResponse;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
-import static ai.asserts.aws.MetricNameUtil.SCRAPE_ACCOUNT_ID_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SCRAPE_NAMESPACE_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
-import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
-import static java.lang.String.format;
 import static java.nio.file.Files.newOutputStream;
 import static org.springframework.util.StringUtils.hasLength;
 
@@ -76,59 +47,35 @@ import static org.springframework.util.StringUtils.hasLength;
  */
 @Slf4j
 @Component
-public class ECSServiceDiscoveryExporter extends Collector implements MetricProvider, InitializingBean {
+public class ECSServiceDiscoveryExporter implements InitializingBean, Runnable {
     public static final String ECS_CONTAINER_METADATA_URI_V4 = "ECS_CONTAINER_METADATA_URI_V4";
     public static final String SCRAPE_ECS_SUBNETS = "SCRAPE_ECS_SUBNETS";
     private final RestTemplate restTemplate;
     private final AccountProvider accountProvider;
     private final ScrapeConfigProvider scrapeConfigProvider;
-    private final AWSClientProvider awsClientProvider;
     private final ResourceMapper resourceMapper;
     private final ECSTaskUtil ecsTaskUtil;
     private final ObjectMapperFactory objectMapperFactory;
-    private final RateLimiter rateLimiter;
-    private final LBToECSRoutingBuilder lbToECSRoutingBuilder;
-    private final MetricSampleBuilder metricSampleBuilder;
 
-    private final ResourceTagHelper resourceTagHelper;
+    private final ECSTaskProvider ecsTaskProvider;
 
-    private final TagUtil tagUtil;
     @Getter
     private final AtomicReference<SubnetDetails> subnetDetails = new AtomicReference<>(null);
 
     @Getter
     protected final Set<String> subnetsToScrape = new TreeSet<>();
 
-    @Getter
-    private volatile List<StaticConfig> targets = new ArrayList<>();
-
-    @Getter
-    private volatile Set<ResourceRelation> routing = new HashSet<>();
-
-    @Getter
-    private volatile List<MetricFamilySamples> taskMetaMetric = new ArrayList<>();
-
-
     public ECSServiceDiscoveryExporter(RestTemplate restTemplate, AccountProvider accountProvider,
-                                       ScrapeConfigProvider scrapeConfigProvider,
-                                       AWSClientProvider awsClientProvider, ResourceMapper resourceMapper,
+                                       ScrapeConfigProvider scrapeConfigProvider, ResourceMapper resourceMapper,
                                        ECSTaskUtil ecsTaskUtil, ObjectMapperFactory objectMapperFactory,
-                                       RateLimiter rateLimiter, LBToECSRoutingBuilder lbToECSRoutingBuilder,
-                                       MetricSampleBuilder metricSampleBuilder,
-                                       ResourceTagHelper resourceTagHelper, TagUtil tagUtil) {
+                                       ECSTaskProvider ecsTaskProvider) {
         this.restTemplate = restTemplate;
         this.accountProvider = accountProvider;
         this.scrapeConfigProvider = scrapeConfigProvider;
-        this.awsClientProvider = awsClientProvider;
         this.resourceMapper = resourceMapper;
         this.ecsTaskUtil = ecsTaskUtil;
         this.objectMapperFactory = objectMapperFactory;
-        this.rateLimiter = rateLimiter;
-        this.lbToECSRoutingBuilder = lbToECSRoutingBuilder;
-        this.metricSampleBuilder = metricSampleBuilder;
-        this.resourceTagHelper = resourceTagHelper;
-        this.tagUtil = tagUtil;
-
+        this.ecsTaskProvider = ecsTaskProvider;
         identifySubnetsToScrape();
     }
 
@@ -190,66 +137,10 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
     }
 
     @Override
-    public List<MetricFamilySamples> collect() {
-        return taskMetaMetric;
-    }
-
-    @Override
-    public void update() {
-        Set<ResourceRelation> newRouting = new HashSet<>();
-        List<Sample> taskMetaMetricSamples = new ArrayList<>();
-        List<StaticConfig> latestTargets = new ArrayList<>();
-
+    public void run() {
         ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
-        log.info("Discovering ECS targets with scrape configs={}", scrapeConfig.getEcsTaskScrapeConfigs());
-        try {
-            accountProvider.getAccounts().forEach(awsAccount -> awsAccount.getRegions().forEach(region -> {
-                String operationName = "EcsClient/listClusters";
-                ImmutableSortedMap<String, String> TELEMETRY_LABELS =
-                        ImmutableSortedMap.of(
-                                SCRAPE_ACCOUNT_ID_LABEL, awsAccount.getAccountId(),
-                                SCRAPE_REGION_LABEL, region,
-                                SCRAPE_OPERATION_LABEL, operationName,
-                                SCRAPE_NAMESPACE_LABEL, "AWS/ECS");
-                SortedMap<String, String> labels = new TreeMap<>(TELEMETRY_LABELS);
-                try {
-                    EcsClient ecsClient = awsClientProvider.getECSClient(region, awsAccount);
-                    // List clusters just returns the cluster ARN. There is no need to paginate
-                    ListClustersResponse listClustersResponse = rateLimiter.doWithRateLimit(operationName,
-                            TELEMETRY_LABELS,
-                            ecsClient::listClusters);
-                    labels.put(SCRAPE_REGION_LABEL, region);
-                    if (listClustersResponse.hasClusterArns()) {
-                        listClustersResponse.clusterArns().stream()
-                                .map(resourceMapper::map)
-                                .filter(Optional::isPresent)
-                                .map(Optional::get)
-                                .forEach(cluster -> latestTargets.addAll(
-                                        buildTargetsInCluster(awsAccount, scrapeConfig, ecsClient, cluster, newRouting,
-                                                taskMetaMetricSamples)));
-                    }
-                } catch (Exception e) {
-                    log.error("Failed to get list of ECS Clusters", e);
-                }
-            }));
-        } catch (Exception e) {
-            log.error("Failed to build ECS Targets", e);
-        }
-
-        routing = newRouting;
-        targets = latestTargets.stream()
-                .filter(config -> shouldScrapeTargets(scrapeConfig, config))
-                .filter(config -> scrapeConfig.keepMetric("up", config.getLabels()))
-                .collect(Collectors.toList());
-
-        if (taskMetaMetricSamples.size() > 0) {
-            metricSampleBuilder.buildFamily(taskMetaMetricSamples).ifPresent(metricFamilySamples ->
-                    taskMetaMetric = Collections.singletonList(metricFamilySamples));
-        } else {
-            taskMetaMetric = Collections.emptyList();
-        }
-
         if (scrapeConfig.isDiscoverECSTasks()) {
+            List<StaticConfig> targets = ecsTaskProvider.getScrapeTargets();
             try {
                 File resultFile = new File(scrapeConfig.getEcsTargetSDFile());
                 ObjectWriter objectWriter = objectMapperFactory.getObjectMapper().writerWithDefaultPrettyPrinter();
@@ -277,177 +168,6 @@ public class ECSServiceDiscoveryExporter extends Collector implements MetricProv
                 !scrapeConfig.isDiscoverOnlySubnetTasks();
         return vpcOK && subnetOK;
     }
-
-    @VisibleForTesting
-    List<StaticConfig> buildTargetsInCluster(AWSAccount awsAccount, ScrapeConfig scrapeConfig, EcsClient ecsClient,
-                                             Resource cluster,
-                                             Set<ResourceRelation> newRouting, List<Sample> taskMetaMetric) {
-        List<StaticConfig> targets = new ArrayList<>();
-        String nextToken;
-        log.info("Discovering ECS targets in cluster={}", cluster.getName());
-        do {
-            // List services just returns the service ARN. There is no need to paginate
-            ListServicesRequest serviceReq = ListServicesRequest.builder()
-                    .cluster(cluster.getName())
-                    .build();
-            String operationName = "EcsClient/listServices";
-            ListServicesResponse serviceResp = rateLimiter.doWithRateLimit(operationName,
-                    ImmutableSortedMap.of(
-                            SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(),
-                            SCRAPE_REGION_LABEL, cluster.getRegion(),
-                            SCRAPE_OPERATION_LABEL, operationName,
-                            SCRAPE_NAMESPACE_LABEL, "AWS/ECS"),
-                    () -> ecsClient.listServices(serviceReq));
-            if (serviceResp.hasServiceArns()) {
-                // Get tags
-                Map<String, Resource> tagsByName =
-                        resourceTagHelper.getResourcesWithTag(awsAccount, cluster.getRegion(), "ecs:service",
-                                serviceResp.serviceArns().stream()
-                                        .map(resourceMapper::map)
-                                        .filter(Optional::isPresent)
-                                        .map(opt -> opt.get().getName())
-                                        .collect(Collectors.toList()));
-
-                List<Resource> services = new ArrayList<>();
-                serviceResp.serviceArns().stream().map(resourceMapper::map).filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .forEach(service -> {
-                            if (scrapeConfig.isDiscoverECSTasks()) {
-                                targets.addAll(
-                                        buildTargetsInService(scrapeConfig, ecsClient, cluster, service, tagsByName,
-                                                taskMetaMetric));
-                            }
-                            services.add(service);
-                        });
-                newRouting.addAll(lbToECSRoutingBuilder.getRoutings(ecsClient, cluster, services));
-            }
-            nextToken = serviceResp.nextToken();
-        } while (nextToken != null);
-
-        Set<String> capturedTasks = targets.stream().map(StaticConfig::getLabels)
-                .map(labels -> format("%s-%s-%s-%s", labels.getAccountId(), labels.getRegion(), labels.getCluster(),
-                        labels.getPod().substring(labels.getWorkload().length() + 1)))
-                .collect(Collectors.toCollection(TreeSet::new));
-
-        // Tasks without service
-        do {
-            // List services just returns the service ARN. There is no need to paginate
-            ListTasksRequest tasksRequest = ListTasksRequest.builder()
-                    .cluster(cluster.getName())
-                    .build();
-            String operationName = "EcsClient/listTasks";
-            ListTasksResponse tasksResponse = rateLimiter.doWithRateLimit(operationName,
-                    ImmutableSortedMap.of(
-                            SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(),
-                            SCRAPE_REGION_LABEL, cluster.getRegion(),
-                            SCRAPE_OPERATION_LABEL, operationName,
-                            SCRAPE_NAMESPACE_LABEL, "AWS/ECS"),
-                    () -> ecsClient.listTasks(tasksRequest));
-            if (tasksResponse.hasTaskArns()) {
-                Set<String> tasksWithoutService = new TreeSet<>();
-                for (String arn : tasksResponse.taskArns()) {
-                    resourceMapper.map(arn).ifPresent(resource -> {
-                        String taskKey = format("%s-%s-%s-%s", resource.getAccount(), resource.getRegion(),
-                                resource.getChildOf().getName(), resource.getName());
-                        if (!capturedTasks.contains(taskKey)) {
-                            tasksWithoutService.add(arn);
-                        }
-                    });
-                }
-                if (tasksWithoutService.size() > 0) {
-                    targets.addAll(buildTaskTargets(scrapeConfig, ecsClient, cluster, Optional.empty(),
-                            new TreeSet<>(tasksWithoutService), Collections.emptyMap(), taskMetaMetric));
-                }
-            }
-            nextToken = tasksResponse.nextToken();
-        } while (nextToken != null);
-
-        return targets;
-    }
-
-    @VisibleForTesting
-    List<StaticConfig> buildTargetsInService(ScrapeConfig scrapeConfig, EcsClient ecsClient, Resource cluster,
-                                             Resource service, Map<String, Resource> resourceWithTags,
-                                             List<Sample> taskMetaMetric) {
-        log.info("Discovering ECS targets in cluster={}, service={}", cluster.getName(), service.getName());
-        List<StaticConfig> scrapeTargets = new ArrayList<>();
-        Set<String> taskARNs = new TreeSet<>();
-        String nextToken = null;
-        Map<String, String> tagLabels = new TreeMap<>();
-        if (resourceWithTags.containsKey(service.getName())) {
-            tagLabels.putAll(tagUtil.tagLabels(resourceWithTags.get(service.getName()).getTags()));
-        }
-        do {
-            ListTasksRequest request = ListTasksRequest.builder()
-                    .cluster(cluster.getName())
-                    .serviceName(service.getName())
-                    .nextToken(nextToken).build();
-            String operationName = "EcsClient/listTasks";
-            ListTasksResponse tasksResp = rateLimiter.doWithRateLimit(operationName,
-                    ImmutableSortedMap.of(SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(), SCRAPE_REGION_LABEL,
-                            cluster.getRegion(), SCRAPE_OPERATION_LABEL, operationName, SCRAPE_NAMESPACE_LABEL,
-                            "AWS/ECS"), () -> ecsClient.listTasks(request));
-
-            nextToken = tasksResp.nextToken();
-            if (tasksResp.hasTaskArns()) {
-                for (String taskArn : tasksResp.taskArns()) {
-                    taskARNs.add(taskArn);
-                    if (taskARNs.size() == 100) {
-                        scrapeTargets.addAll(buildTaskTargets(scrapeConfig, ecsClient, cluster, Optional.of(service),
-                                taskARNs, tagLabels, taskMetaMetric));
-                        taskARNs = new TreeSet<>();
-                    }
-                }
-            }
-        } while (nextToken != null);
-
-        // Either the first batch was less than 100 or this is the last batch
-        if (taskARNs.size() > 0) {
-            scrapeTargets.addAll(buildTaskTargets(scrapeConfig, ecsClient, cluster, Optional.of(service), taskARNs,
-                    tagLabels, taskMetaMetric));
-        }
-        return scrapeTargets;
-    }
-
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    @VisibleForTesting
-    List<StaticConfig> buildTaskTargets(ScrapeConfig scrapeConfig, EcsClient ecsClient, Resource cluster,
-                                        Optional<Resource> service, Set<String> taskARNs,
-                                        Map<String, String> tagLabels, List<Sample> taskMetaMetric) {
-        service.ifPresent(serviceRes ->
-                log.info("Building ECS targets in cluster={}, service={}", cluster.getName(), serviceRes.getName()));
-
-        List<StaticConfig> configs = new ArrayList<>();
-        DescribeTasksRequest request =
-                DescribeTasksRequest.builder().cluster(cluster.getName()).tasks(taskARNs).build();
-        String operationName = "EcsClient/describeTasks";
-        DescribeTasksResponse taskResponse = rateLimiter.doWithRateLimit(operationName,
-                ImmutableSortedMap.of(SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(), SCRAPE_REGION_LABEL,
-                        cluster.getRegion(), SCRAPE_OPERATION_LABEL, operationName, SCRAPE_NAMESPACE_LABEL,
-                        "AWS/ECS"), () -> ecsClient.describeTasks(request));
-        if (taskResponse.hasTasks()) {
-            configs.addAll(taskResponse.tasks().stream()
-                    .filter(ecsTaskUtil::hasAllInfo)
-                    .flatMap(task -> {
-                        Map<String, String> labels = new TreeMap<>();
-                        labels.put(SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount());
-                        labels.put(SCRAPE_REGION_LABEL, cluster.getRegion());
-                        labels.put("cluster", cluster.getName());
-                        resourceMapper.map(task.taskDefinitionArn()).ifPresent(res -> labels.put("taskdef_family",
-                                res.getName()));
-                        labels.put("taskdef_version", task.version().toString());
-                        service.ifPresent(res -> labels.put("service", res.getName()));
-                        resourceMapper.map(task.taskArn()).ifPresent(res -> labels.put("task_id", res.getName()));
-                        metricSampleBuilder.buildSingleSample("aws_ecs_task_info", labels, 1.0D)
-                                .ifPresent(taskMetaMetric::add);
-                        return ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster, service,
-                                task, tagLabels).stream();
-                    })
-                    .collect(Collectors.toList()));
-        }
-        return configs;
-    }
-
 
     @VisibleForTesting
     String getMetaDataURI() {

--- a/src/main/java/ai/asserts/aws/exporter/ECSTaskProvider.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSTaskProvider.java
@@ -1,0 +1,201 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.AWSClientProvider;
+import ai.asserts.aws.AccountProvider;
+import ai.asserts.aws.AccountProvider.AWSAccount;
+import ai.asserts.aws.RateLimiter;
+import ai.asserts.aws.ScrapeConfigProvider;
+import ai.asserts.aws.config.ScrapeConfig;
+import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
+import ai.asserts.aws.resource.Resource;
+import ai.asserts.aws.resource.ResourceMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSortedMap;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import io.prometheus.client.CollectorRegistry;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.DescribeTasksRequest;
+import software.amazon.awssdk.services.ecs.model.DescribeTasksResponse;
+import software.amazon.awssdk.services.ecs.model.DesiredStatus;
+import software.amazon.awssdk.services.ecs.model.ListTasksRequest;
+import software.amazon.awssdk.services.ecs.model.ListTasksResponse;
+import software.amazon.awssdk.services.ecs.model.Task;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_ACCOUNT_ID_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_NAMESPACE_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_OPERATION_LABEL;
+import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
+
+@Component
+@Slf4j
+public class ECSTaskProvider extends Collector implements InitializingBean {
+    public static final String TASK_META_METRIC = "aws_ecs_task_info";
+    private final AWSClientProvider awsClientProvider;
+    private final ScrapeConfigProvider scrapeConfigProvider;
+    private final AccountProvider accountProvider;
+    private final RateLimiter rateLimiter;
+    private final ResourceMapper resourceMapper;
+    private final ECSClusterProvider ecsClusterProvider;
+    private final ECSTaskUtil ecsTaskUtil;
+    private final MetricSampleBuilder sampleBuilder;
+
+    private final CollectorRegistry collectorRegistry;
+
+    @Getter
+    @VisibleForTesting
+    private final Map<Resource, Map<Resource, List<StaticConfig>>> tasksByCluster = new HashMap<>();
+
+    public ECSTaskProvider(AWSClientProvider awsClientProvider, ScrapeConfigProvider scrapeConfigProvider,
+                           AccountProvider accountProvider, RateLimiter rateLimiter, ResourceMapper resourceMapper,
+                           ECSClusterProvider ecsClusterProvider, ECSTaskUtil ecsTaskUtil,
+                           MetricSampleBuilder sampleBuilder, CollectorRegistry collectorRegistry) {
+        this.awsClientProvider = awsClientProvider;
+        this.scrapeConfigProvider = scrapeConfigProvider;
+        this.accountProvider = accountProvider;
+        this.rateLimiter = rateLimiter;
+        this.resourceMapper = resourceMapper;
+        this.ecsClusterProvider = ecsClusterProvider;
+        this.ecsTaskUtil = ecsTaskUtil;
+        this.sampleBuilder = sampleBuilder;
+        this.collectorRegistry = collectorRegistry;
+    }
+
+    @Override
+    public List<MetricFamilySamples> collect() {
+        List<Sample> samples = new ArrayList<>();
+        tasksByCluster.values().stream()
+                .flatMap(taskMap -> taskMap.values().stream())
+                .flatMap(Collection::stream)
+                .forEach(target ->
+                        sampleBuilder.buildSingleSample(TASK_META_METRIC, target.getLabels(), 1.0D)
+                                .ifPresent(samples::add));
+        List<MetricFamilySamples> familySamples = new ArrayList<>();
+        sampleBuilder.buildFamily(samples).ifPresent(familySamples::add);
+        return familySamples;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        collectorRegistry.register(this);
+    }
+
+    public List<StaticConfig> getScrapeTargets() {
+        ScrapeConfig scrapeConfig = scrapeConfigProvider.getScrapeConfig();
+        for (AWSAccount account : accountProvider.getAccounts()) {
+            for (String region : account.getRegions()) {
+                Map<Resource, List<Resource>> clusterWiseNewTasks = new HashMap<>();
+                EcsClient ecsClient = awsClientProvider.getECSClient(region, account);
+                for (Resource cluster : ecsClusterProvider.getClusters(account, region)) {
+                    discoverNewTasks(clusterWiseNewTasks, ecsClient, cluster);
+                }
+                buildNewTargets(account,scrapeConfig, clusterWiseNewTasks, ecsClient);
+            }
+        }
+
+        return tasksByCluster.values().stream()
+                .flatMap(taskMap -> taskMap.values().stream())
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    @VisibleForTesting
+    void discoverNewTasks(Map<Resource, List<Resource>> clusterWiseNewTasks, EcsClient ecsClient, Resource cluster) {
+        Map<Resource, List<StaticConfig>> current =
+                tasksByCluster.computeIfAbsent(cluster, k -> new HashMap<>());
+        Paginator taskPaginator = new Paginator();
+        Set<Resource> latestTasks = new LinkedHashSet<>();
+        do {
+            ListTasksRequest tasksRequest = ListTasksRequest.builder()
+                    .cluster(cluster.getName())
+                    .desiredStatus(DesiredStatus.RUNNING)
+                    .nextToken(taskPaginator.getNextToken())
+                    .build();
+            String operationName = "EcsClient/listTasks";
+            ListTasksResponse tasksResponse = rateLimiter.doWithRateLimit(operationName,
+                    ImmutableSortedMap.of(
+                            SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(),
+                            SCRAPE_REGION_LABEL, cluster.getRegion(),
+                            SCRAPE_OPERATION_LABEL, operationName,
+                            SCRAPE_NAMESPACE_LABEL, "AWS/ECS"),
+                    () -> ecsClient.listTasks(tasksRequest));
+
+            // Build list of new tasks for which we need to make the describeTasks call
+            if (tasksResponse.hasTaskArns()) {
+                // Build the current task list
+                latestTasks.addAll(tasksResponse.taskArns().stream()
+                        .map(resourceMapper::map)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .collect(Collectors.toSet()));
+            }
+            taskPaginator.nextToken(tasksResponse.nextToken());
+        } while (taskPaginator.hasNext());
+
+        // Remove tasks that are not present
+        // Retain only new tasks
+        current.entrySet().removeIf(entry -> !latestTasks.contains(entry.getKey()));
+        latestTasks.removeIf(current::containsKey);
+        clusterWiseNewTasks.computeIfAbsent(cluster, k -> new ArrayList<>()).addAll(latestTasks);
+    }
+
+    @VisibleForTesting
+    void buildNewTargets(AWSAccount account, ScrapeConfig scrapeConfig,
+                         Map<Resource, List<Resource>> clusterWiseNewTasks,
+                         EcsClient ecsClient) {
+        // Make the describeTasks call for the new tasks and build the scrape targets
+        clusterWiseNewTasks.forEach((cluster, tasks) -> {
+            String operationName = "EcsClient/describeTasks";
+            DescribeTasksRequest request =
+                    DescribeTasksRequest.builder()
+                            .cluster(cluster.getName())
+                            .tasks(tasks.stream().map(Resource::getArn).collect(Collectors.toList()))
+                            .build();
+            DescribeTasksResponse taskResponse = rateLimiter.doWithRateLimit(operationName,
+                    ImmutableSortedMap.of(
+                            SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(),
+                            SCRAPE_REGION_LABEL, cluster.getRegion(),
+                            SCRAPE_OPERATION_LABEL, operationName,
+                            SCRAPE_NAMESPACE_LABEL, "AWS/ECS"),
+                    () -> ecsClient.describeTasks(request));
+            if (taskResponse.hasTasks()) {
+                taskResponse.tasks().stream()
+                        .filter(ecsTaskUtil::hasAllInfo)
+                        .filter(ecsTaskUtil::hasAllInfo)
+                        .forEach(task -> resourceMapper.map(task.taskArn()).ifPresent(taskResource -> {
+                            List<StaticConfig> staticConfigs =
+                                    ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster,
+                                            getService(task), task);
+                            Map<Resource, List<StaticConfig>> clusterTargets =
+                                    tasksByCluster.computeIfAbsent(cluster, k -> new HashMap<>());
+                            clusterTargets.put(taskResource, staticConfigs);
+                        }));
+            }
+        });
+    }
+
+
+    Optional<String> getService(Task task) {
+        return task.group() != null && task.group().contains("service:") ?
+                Optional.of(task.group().split(":")[1]) : Optional.empty();
+    }
+
+}

--- a/src/main/java/ai/asserts/aws/exporter/LBToECSRoutingBuilder.java
+++ b/src/main/java/ai/asserts/aws/exporter/LBToECSRoutingBuilder.java
@@ -4,19 +4,27 @@
  */
 package ai.asserts.aws.exporter;
 
+import ai.asserts.aws.AWSClientProvider;
+import ai.asserts.aws.AccountProvider;
 import ai.asserts.aws.RateLimiter;
 import ai.asserts.aws.resource.Resource;
 import ai.asserts.aws.resource.ResourceMapper;
 import ai.asserts.aws.resource.ResourceRelation;
 import com.google.common.collect.ImmutableSortedMap;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.ecs.model.DescribeServicesRequest;
 import software.amazon.awssdk.services.ecs.model.DescribeServicesResponse;
+import software.amazon.awssdk.services.ecs.model.ListServicesRequest;
+import software.amazon.awssdk.services.ecs.model.ListServicesResponse;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -28,55 +36,94 @@ import static ai.asserts.aws.MetricNameUtil.SCRAPE_REGION_LABEL;
 
 @Component
 @Slf4j
-public class LBToECSRoutingBuilder {
+public class LBToECSRoutingBuilder implements Runnable {
     private final RateLimiter rateLimiter;
     private final ResourceMapper resourceMapper;
     private final TargetGroupLBMapProvider targetGroupLBMapProvider;
 
+    private final AWSClientProvider awsClientProvider;
+
+    private final AccountProvider accountProvider;
+
+    @Getter
+    private volatile Set<ResourceRelation> routing = new HashSet<>();
+
     public LBToECSRoutingBuilder(RateLimiter rateLimiter, ResourceMapper resourceMapper,
-                                 TargetGroupLBMapProvider targetGroupLBMapProvider) {
+                                 TargetGroupLBMapProvider targetGroupLBMapProvider,
+                                 AWSClientProvider awsClientProvider, AccountProvider accountProvider) {
         this.rateLimiter = rateLimiter;
         this.resourceMapper = resourceMapper;
         this.targetGroupLBMapProvider = targetGroupLBMapProvider;
+        this.awsClientProvider = awsClientProvider;
+        this.accountProvider = accountProvider;
     }
 
-    public Set<ResourceRelation> getRoutings(EcsClient ecsClient, Resource cluster, List<Resource> services) {
-        Set<ResourceRelation> routing = new HashSet<>();
-        log.info("Updating Resource Relation for ECS Cluster {}", cluster);
-        if (services.size() > 0) {
-            try {
-                String api = "EcsClient/describeServices";
-                DescribeServicesResponse response = rateLimiter.doWithRateLimit(api,
-                        ImmutableSortedMap.of(
-                                SCRAPE_REGION_LABEL, cluster.getRegion(),
-                                SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(),
-                                SCRAPE_OPERATION_LABEL, api
-                        )
-                        , () -> ecsClient.describeServices(DescribeServicesRequest.builder()
-                                .cluster(cluster.getArn())
-                                .services(services.stream().map(Resource::getArn).collect(Collectors.toList()))
-                                .build()));
-                if (response.hasServices()) {
-                    response.services().stream()
-                            .filter(service -> resourceMapper.map(service.serviceArn()).isPresent()).forEach(service -> {
-                        Optional<Resource> servResOpt = resourceMapper.map(service.serviceArn());
-                        servResOpt.ifPresent(servRes -> routing.addAll(service.loadBalancers().stream()
-                                .map(loadBalancer -> resourceMapper.map(loadBalancer.targetGroupArn()))
-                                .filter(Optional::isPresent).map(Optional::get)
-                                .map(tg -> targetGroupLBMapProvider.getTgToLB().get(tg))
-                                .filter(Objects::nonNull)
-                                .map(lb -> ResourceRelation.builder()
-                                        .from(lb)
-                                        .to(servRes)
-                                        .name("ROUTES_TO")
-                                        .build())
-                                .collect(Collectors.toSet())));
-                    });
+    public void run() {
+        Set<ResourceRelation> newRouting = new HashSet<>();
+        accountProvider.getAccounts().forEach(awsAccount -> awsAccount.getRegions().forEach(region -> {
+            EcsClient ecsClient = awsClientProvider.getECSClient(region, awsAccount);
+            Map<String, List<String>> serviceARNsByCluster = new HashMap<>();
+            Paginator paginator = new Paginator();
+            do {
+                String api = "EcsClient/listServices";
+                ListServicesResponse response = rateLimiter.doWithRateLimit(api, ImmutableSortedMap.of(
+                        SCRAPE_REGION_LABEL, region,
+                        SCRAPE_ACCOUNT_ID_LABEL, awsAccount.getAccountId(),
+                        SCRAPE_OPERATION_LABEL, api
+                ), () -> ecsClient.listServices(ListServicesRequest.builder()
+                        .nextToken(paginator.getNextToken())
+                        .build()));
+                if (response.hasServiceArns()) {
+                    response.serviceArns().stream()
+                            .map(resourceMapper::map)
+                            .filter(Optional::isPresent)
+                            .map(Optional::get)
+                            .forEach(service -> serviceARNsByCluster.computeIfAbsent(service.getChildOf().getName(),
+                                    k -> new ArrayList<>()).add(service.getArn()));
                 }
-            } catch (Exception e) {
-                log.error("Failed to build resource relations", e);
-            }
-        }
-        return routing;
+                paginator.nextToken(response.nextToken());
+            } while (paginator.hasNext());
+
+
+            serviceARNsByCluster.forEach((cluster, _ARNs) -> {
+                try {
+                    String api = "EcsClient/describeServices";
+                    DescribeServicesResponse response = rateLimiter.doWithRateLimit(api,
+                            ImmutableSortedMap.of(
+                                    SCRAPE_REGION_LABEL, region,
+                                    SCRAPE_ACCOUNT_ID_LABEL, awsAccount.getAccountId(),
+                                    SCRAPE_OPERATION_LABEL, api
+                            )
+                            , () -> ecsClient.describeServices(DescribeServicesRequest.builder()
+                                    .cluster(cluster)
+                                    .services(_ARNs)
+                                    .build()));
+                    if (response.hasServices()) {
+                        response.services().stream()
+                                .filter(service -> resourceMapper.map(service.serviceArn()).isPresent())
+                                .forEach(service -> {
+                                    Optional<Resource> servResOpt = resourceMapper.map(service.serviceArn());
+                                    servResOpt.ifPresent(
+                                            servRes -> newRouting.addAll(service.loadBalancers().stream()
+                                                    .map(loadBalancer -> resourceMapper.map(
+                                                            loadBalancer.targetGroupArn()))
+                                                    .filter(Optional::isPresent).map(Optional::get)
+                                                    .map(tg -> targetGroupLBMapProvider.getTgToLB().get(tg))
+                                                    .filter(Objects::nonNull)
+                                                    .map(lb -> ResourceRelation.builder()
+                                                            .from(lb)
+                                                            .to(servRes)
+                                                            .name("ROUTES_TO")
+                                                            .build())
+                                                    .collect(Collectors.toSet())));
+                                });
+                    }
+                } catch (Exception e) {
+                    log.error("Failed to build resource relations", e);
+                }
+            });
+        }));
+        routing = newRouting;
     }
+
 }

--- a/src/main/java/ai/asserts/aws/exporter/Paginator.java
+++ b/src/main/java/ai/asserts/aws/exporter/Paginator.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import lombok.Getter;
+
+@Getter
+public class Paginator {
+    private String lastToken;
+    private String nextToken;
+
+    public void nextToken(String newNextToken) {
+        lastToken = nextToken;
+        nextToken = newNextToken;
+    }
+
+    public boolean hasNext() {
+        return nextToken != null && !nextToken.equalsIgnoreCase(lastToken);
+    }
+}

--- a/src/main/java/ai/asserts/aws/exporter/ResourceRelationExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ResourceRelationExporter.java
@@ -19,23 +19,23 @@ import java.util.TreeMap;
 @Component
 @Slf4j
 public class ResourceRelationExporter extends Collector implements MetricProvider {
-    private final ECSServiceDiscoveryExporter ecsServiceDiscoveryExporter;
     private final LBToASGRelationBuilder lbToASGRelationBuilder;
     private final LBToLambdaRoutingBuilder lbToLambdaRoutingBuilder;
+    private final LBToECSRoutingBuilder lbToECSRoutingBuilder;
     private final EC2ToEBSVolumeExporter ec2ToEBSVolumeExporter;
     private final ApiGatewayToLambdaBuilder apiGatewayToLambdaBuilder;
     private final MetricSampleBuilder sampleBuilder;
     private volatile List<MetricFamilySamples> metrics = new ArrayList<>();
 
-    public ResourceRelationExporter(ECSServiceDiscoveryExporter ecsServiceDiscoveryExporter,
-                                    LBToASGRelationBuilder lbToASGRelationBuilder,
+    public ResourceRelationExporter(LBToASGRelationBuilder lbToASGRelationBuilder,
                                     LBToLambdaRoutingBuilder lbToLambdaRoutingBuilder,
+                                    LBToECSRoutingBuilder lbToECSRoutingBuilder,
                                     EC2ToEBSVolumeExporter ec2ToEBSVolumeExporter,
                                     ApiGatewayToLambdaBuilder apiGatewayToLambdaBuilder,
                                     MetricSampleBuilder sampleBuilder) {
-        this.ecsServiceDiscoveryExporter = ecsServiceDiscoveryExporter;
         this.lbToASGRelationBuilder = lbToASGRelationBuilder;
         this.lbToLambdaRoutingBuilder = lbToLambdaRoutingBuilder;
+        this.lbToECSRoutingBuilder = lbToECSRoutingBuilder;
         this.ec2ToEBSVolumeExporter = ec2ToEBSVolumeExporter;
         this.apiGatewayToLambdaBuilder = apiGatewayToLambdaBuilder;
         this.sampleBuilder = sampleBuilder;
@@ -52,7 +52,7 @@ public class ResourceRelationExporter extends Collector implements MetricProvide
         try {
             List<MetricFamilySamples> familySamples = new ArrayList<>();
             List<MetricFamilySamples.Sample> samples = new ArrayList<>();
-            Set<ResourceRelation> relations = new HashSet<>(ecsServiceDiscoveryExporter.getRouting());
+            Set<ResourceRelation> relations = new HashSet<>(lbToECSRoutingBuilder.getRouting());
             relations.addAll(lbToASGRelationBuilder.getRoutingConfigs());
             relations.addAll(lbToLambdaRoutingBuilder.getRoutings());
             relations.addAll(ec2ToEBSVolumeExporter.getAttachedVolumes());

--- a/src/main/java/ai/asserts/aws/exporter/TargetGroupLBMapProvider.java
+++ b/src/main/java/ai/asserts/aws/exporter/TargetGroupLBMapProvider.java
@@ -188,7 +188,7 @@ public class TargetGroupLBMapProvider extends Collector implements InitializingB
                                 "ElasticLoadBalancingV2Client/describeTargetGroups");
                         DescribeTargetGroupsResponse tgr =
                                 rateLimiter.doWithRateLimit("ElasticLoadBalancingV2Client/describeTargetGroups",
-                                        ImmutableSortedMap.of(),
+                                        telemetryLabels,
                                         () -> lbClient.describeTargetGroups(DescribeTargetGroupsRequest.builder()
                                                 .targetGroupArns(action.targetGroupArn())
                                                 .build()));
@@ -198,10 +198,12 @@ public class TargetGroupLBMapProvider extends Collector implements InitializingB
                                     .filter(targetGroup -> targetGroup.targetType()
                                             .equals(INSTANCE))
                                     .forEach(targetGroup -> {
+                                        telemetryLabels.put(SCRAPE_OPERATION_LABEL,
+                                                "ElasticLoadBalancingV2Client/describeTargetHealth");
                                         DescribeTargetHealthResponse thr =
                                                 rateLimiter.doWithRateLimit(
                                                         "ElasticLoadBalancingV2Client/describeTargetHealth",
-                                                        ImmutableSortedMap.of(),
+                                                        telemetryLabels,
                                                         () -> lbClient.describeTargetHealth(
                                                                 DescribeTargetHealthRequest.builder()
                                                                         .targetGroupArn(action.targetGroupArn())

--- a/src/test/java/ai/asserts/aws/MetadataTaskManagerTest.java
+++ b/src/test/java/ai/asserts/aws/MetadataTaskManagerTest.java
@@ -128,7 +128,6 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
         expect(lambdaInvokeConfigExporter.register(collectorRegistry)).andReturn(null);
         expect(metricCollector.register(collectorRegistry)).andReturn(null);
         expect(relationExporter.register(collectorRegistry)).andReturn(null);
-        expect(ecsServiceDiscoveryExporter.register(collectorRegistry)).andReturn(null);
         expect(loadBalancerExporter.register(collectorRegistry)).andReturn(null);
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
         expect(scrapeConfig.getLambdaConfig()).andReturn(Optional.of(namespaceConfig));
@@ -140,7 +139,6 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
 
     @Test
     public void afterPropertiesSet_notPrimaryExporter() {
-        expect(ecsServiceDiscoveryExporter.register(collectorRegistry)).andReturn(null);
         expect(ecsServiceDiscoveryExporter.isPrimaryExporter()).andReturn(false);
         replayAll();
         testClass.afterPropertiesSet();
@@ -273,7 +271,7 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig).anyTimes();
         expect(executorService.submit(capture(capture1))).andReturn(null);
         scrapeConfigProvider.update();
-        ecsServiceDiscoveryExporter.update();
+        ecsServiceDiscoveryExporter.run();
         replayAll();
 
         testClass.perMinute();

--- a/src/test/java/ai/asserts/aws/MetadataTaskManagerTest.java
+++ b/src/test/java/ai/asserts/aws/MetadataTaskManagerTest.java
@@ -17,6 +17,7 @@ import ai.asserts.aws.exporter.KinesisAnalyticsExporter;
 import ai.asserts.aws.exporter.KinesisFirehoseExporter;
 import ai.asserts.aws.exporter.KinesisStreamExporter;
 import ai.asserts.aws.exporter.LBToASGRelationBuilder;
+import ai.asserts.aws.exporter.LBToECSRoutingBuilder;
 import ai.asserts.aws.exporter.LambdaCapacityExporter;
 import ai.asserts.aws.exporter.LambdaEventSourceExporter;
 import ai.asserts.aws.exporter.LambdaInvokeConfigExporter;
@@ -61,6 +62,7 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
     private ResourceRelationExporter relationExporter;
     private TargetGroupLBMapProvider targetGroupLBMapProvider;
     private LBToASGRelationBuilder lbToASGRelationBuilder;
+    private LBToECSRoutingBuilder lbToECSRoutingBuilder;
     private EC2ToEBSVolumeExporter ec2ToEBSVolumeExporter;
     private ApiGatewayToLambdaBuilder apiGatewayToLambdaBuilder;
     private KinesisAnalyticsExporter kinesisAnalyticsExporter;
@@ -95,6 +97,7 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
         relationExporter = mock(ResourceRelationExporter.class);
         targetGroupLBMapProvider = mock(TargetGroupLBMapProvider.class);
         lbToASGRelationBuilder = mock(LBToASGRelationBuilder.class);
+        lbToECSRoutingBuilder = mock(LBToECSRoutingBuilder.class);
         ec2ToEBSVolumeExporter = mock(EC2ToEBSVolumeExporter.class);
         apiGatewayToLambdaBuilder = mock(ApiGatewayToLambdaBuilder.class);
         kinesisAnalyticsExporter = mock(KinesisAnalyticsExporter.class);
@@ -109,10 +112,12 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
         dynamoDBExporter = mock(DynamoDBExporter.class);
         snsTopicExporter = mock(SNSTopicExporter.class);
         emrExporter = mock(EMRExporter.class);
+
         testClass = new MetadataTaskManager(
                 collectorRegistry, lambdaFunctionScraper, lambdaCapacityExporter, lambdaEventSourceExporter,
                 lambdaInvokeConfigExporter, logMetricScrapeTask, metricCollector,
-                targetGroupLBMapProvider, relationExporter, lbToASGRelationBuilder, ec2ToEBSVolumeExporter,
+                targetGroupLBMapProvider, relationExporter, lbToASGRelationBuilder, lbToECSRoutingBuilder,
+                ec2ToEBSVolumeExporter,
                 apiGatewayToLambdaBuilder, kinesisAnalyticsExporter, kinesisFirehoseExporter,
                 s3BucketExporter, taskThreadPool, scrapeConfigProvider, ecsServiceDiscoveryExporter, redshiftExporter,
                 sqsQueueExporter, kinesisStreamExporter, loadBalancerExporter, rdsExporter, dynamoDBExporter,
@@ -174,6 +179,7 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
         Capture<Runnable> capture18 = newCapture();
         Capture<Runnable> capture19 = newCapture();
         Capture<Runnable> capture20 = newCapture();
+        Capture<Runnable> capture21 = newCapture();
 
         expect(executorService.submit(capture(capture0))).andReturn(null);
         expect(executorService.submit(capture(capture1))).andReturn(null);
@@ -196,6 +202,7 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
         expect(executorService.submit(capture(capture18))).andReturn(null);
         expect(executorService.submit(capture(capture19))).andReturn(null);
         expect(executorService.submit(capture(capture20))).andReturn(null);
+        expect(executorService.submit(capture(capture21))).andReturn(null);
 
         lambdaFunctionScraper.update();
         lambdaCapacityExporter.update();
@@ -218,6 +225,7 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
         dynamoDBExporter.update();
         snsTopicExporter.update();
         emrExporter.update();
+        lbToECSRoutingBuilder.run();
 
         replayAll();
         testClass.updateMetadata();
@@ -243,6 +251,7 @@ public class MetadataTaskManagerTest extends EasyMockSupport {
         capture18.getValue().run();
         capture19.getValue().run();
         capture20.getValue().run();
+        capture21.getValue().run();
 
         verifyAll();
     }

--- a/src/test/java/ai/asserts/aws/exporter/ECSClusterProviderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSClusterProviderTest.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.AWSClientProvider;
+import ai.asserts.aws.AccountProvider;
+import ai.asserts.aws.AccountProvider.AWSAccount;
+import ai.asserts.aws.RateLimiter;
+import ai.asserts.aws.resource.Resource;
+import ai.asserts.aws.resource.ResourceMapper;
+import com.google.common.collect.ImmutableSet;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.Cluster;
+import software.amazon.awssdk.services.ecs.model.DescribeClustersRequest;
+import software.amazon.awssdk.services.ecs.model.DescribeClustersResponse;
+import software.amazon.awssdk.services.ecs.model.ListClustersResponse;
+
+import java.util.Optional;
+import java.util.SortedMap;
+
+import static org.easymock.EasyMock.anyLong;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ECSClusterProviderTest extends EasyMockSupport {
+    private AWSClientProvider awsClientProvider;
+    private EcsClient ecsClient;
+    private ResourceMapper resourceMapper;
+    private BasicMetricCollector metricCollector;
+    private ECSClusterProvider testClass;
+    private Resource clusterResource1;
+    private Resource clusterResource2;
+
+    @BeforeEach
+    public void setup() {
+        awsClientProvider = mock(AWSClientProvider.class);
+        resourceMapper = mock(ResourceMapper.class);
+        metricCollector = mock(BasicMetricCollector.class);
+        ecsClient = mock(EcsClient.class);
+        clusterResource1 = mock(Resource.class);
+        clusterResource2 = mock(Resource.class);
+        testClass = new ECSClusterProvider(awsClientProvider, new RateLimiter(metricCollector), resourceMapper);
+    }
+
+    @Test
+    public void getClusters() {
+        AWSAccount awsAccount = AWSAccount.builder()
+                .name("test-account")
+                .regions(ImmutableSet.of("region"))
+                .accountId("account-1")
+                .build();
+        expect(awsClientProvider.getECSClient("region", awsAccount)).andReturn(ecsClient);
+        ListClustersResponse listClustersResponse = ListClustersResponse.builder()
+                .clusterArns("cluster-arn1", "cluster-arn2")
+                .build();
+        expect(ecsClient.listClusters()).andReturn(listClustersResponse);
+        metricCollector.recordLatency(eq("aws_exporter_milliseconds"), anyObject(SortedMap.class), anyLong());
+
+        expect(ecsClient.describeClusters(DescribeClustersRequest.builder()
+                .clusters(ImmutableSet.of("cluster-arn1", "cluster-arn2"))
+                .build())).andReturn(
+                DescribeClustersResponse.builder()
+                        .clusters(
+                                Cluster.builder().clusterArn("cluster-arn1").status("ACTIVE").build(),
+                                Cluster.builder().clusterArn("cluster-arn2").status("ACTIVE").build(),
+                                Cluster.builder().clusterArn("cluster-arn3").status("INACTIVE").build(),
+                                Cluster.builder().clusterArn("cluster-arn4").status("PROVISIONING").build(),
+                                Cluster.builder().clusterArn("cluster-arn5").status("DEPROVISIONING").build(),
+                                Cluster.builder().clusterArn("cluster-arn6").status("FAILED").build()
+                        )
+                        .build()
+        );
+        metricCollector.recordLatency(eq("aws_exporter_milliseconds"), anyObject(SortedMap.class), anyLong());
+        expect(resourceMapper.map("cluster-arn1")).andReturn(Optional.of(clusterResource1));
+        expect(resourceMapper.map("cluster-arn2")).andReturn(Optional.of(clusterResource2));
+        replayAll();
+        assertEquals(ImmutableSet.of(clusterResource1, clusterResource2), testClass.getClusters(awsAccount, "region"));
+        verifyAll();
+    }
+}

--- a/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryControllerTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryControllerTest.java
@@ -20,10 +20,10 @@ public class ECSServiceDiscoveryControllerTest extends EasyMockSupport {
 
     @Test
     public void getECSSDConfig() {
-        ECSServiceDiscoveryExporter mockExporter = mock(ECSServiceDiscoveryExporter.class);
+        ECSTaskProvider mockExporter = mock(ECSTaskProvider.class);
         List mockConfig = mock(List.class);
 
-        expect(mockExporter.getTargets()).andReturn(mockConfig);
+        expect(mockExporter.getScrapeTargets()).andReturn(mockConfig);
 
         replayAll();
         ECSServiceDiscoveryController testClass = new ECSServiceDiscoveryController(mockExporter);

--- a/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
@@ -4,124 +4,64 @@
  */
 package ai.asserts.aws.exporter;
 
-import ai.asserts.aws.AWSClientProvider;
 import ai.asserts.aws.AccountProvider;
-import ai.asserts.aws.AccountProvider.AWSAccount;
 import ai.asserts.aws.ObjectMapperFactory;
-import ai.asserts.aws.RateLimiter;
 import ai.asserts.aws.ScrapeConfigProvider;
-import ai.asserts.aws.TagUtil;
 import ai.asserts.aws.config.ScrapeConfig;
 import ai.asserts.aws.config.ScrapeConfig.SubnetDetails;
 import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
 import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.TaskMetaData;
 import ai.asserts.aws.resource.Resource;
 import ai.asserts.aws.resource.ResourceMapper;
-import ai.asserts.aws.resource.ResourceRelation;
-import ai.asserts.aws.resource.ResourceTagHelper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Sets;
-import io.prometheus.client.Collector.MetricFamilySamples;
-import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import org.easymock.EasyMockSupport;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.client.RestTemplate;
-import software.amazon.awssdk.services.ecs.EcsClient;
-import software.amazon.awssdk.services.ecs.model.DescribeTasksRequest;
-import software.amazon.awssdk.services.ecs.model.DescribeTasksResponse;
-import software.amazon.awssdk.services.ecs.model.ListClustersResponse;
-import software.amazon.awssdk.services.ecs.model.ListServicesRequest;
-import software.amazon.awssdk.services.ecs.model.ListServicesResponse;
-import software.amazon.awssdk.services.ecs.model.ListTasksRequest;
-import software.amazon.awssdk.services.ecs.model.ListTasksResponse;
-import software.amazon.awssdk.services.ecs.model.Task;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
-import static ai.asserts.aws.MetricNameUtil.SCRAPE_ERROR_COUNT_METRIC;
-import static ai.asserts.aws.MetricNameUtil.SCRAPE_LATENCY_METRIC;
-import static ai.asserts.aws.resource.ResourceType.ECSCluster;
-import static ai.asserts.aws.resource.ResourceType.ECSService;
-import static org.easymock.EasyMock.anyLong;
 import static org.easymock.EasyMock.anyObject;
-import static org.easymock.EasyMock.anyString;
 import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
     private RestTemplate restTemplate;
-    private AWSAccount account;
     private AccountProvider accountProvider;
     private ScrapeConfigProvider scrapeConfigProvider;
     private ScrapeConfig scrapeConfig;
-    private AWSClientProvider awsClientProvider;
-    private EcsClient ecsClient;
-    private LBToECSRoutingBuilder lbToECSRoutingBuilder;
     private ResourceMapper resourceMapper;
     private Resource resource;
     private ECSTaskUtil ecsTaskUtil;
-    private BasicMetricCollector metricCollector;
     private ObjectMapperFactory objectMapperFactory;
-    private RateLimiter rateLimiter;
     private ObjectMapper objectMapper;
     private ObjectWriter objectWriter;
-    private MetricSampleBuilder metricSampleBuilder;
     private StaticConfig mockStaticConfig;
     private Labels mockLabels;
-    private ResourceRelation mockRelation;
-    private Sample sample;
-    private MetricFamilySamples metricFamilySamples;
-
-    private ResourceTagHelper resourceTagHelper;
-
-    private TagUtil tagUtil;
+    private ECSTaskProvider ecsTaskProvider;
 
     @BeforeEach
     public void setup() {
         restTemplate = mock(RestTemplate.class);
-        account = new AWSAccount("account", "", "", "",
-                ImmutableSet.of("region1", "region2"));
         accountProvider = mock(AccountProvider.class);
         scrapeConfigProvider = mock(ScrapeConfigProvider.class);
         scrapeConfig = mock(ScrapeConfig.class);
-        awsClientProvider = mock(AWSClientProvider.class);
-        ecsClient = mock(EcsClient.class);
         resourceMapper = mock(ResourceMapper.class);
         resource = mock(Resource.class);
         ecsTaskUtil = mock(ECSTaskUtil.class);
-        metricCollector = mock(BasicMetricCollector.class);
         objectMapperFactory = mock(ObjectMapperFactory.class);
         objectMapper = mock(ObjectMapper.class);
         objectWriter = mock(ObjectWriter.class);
         mockStaticConfig = mock(StaticConfig.class);
-        lbToECSRoutingBuilder = mock(LBToECSRoutingBuilder.class);
-        mockRelation = mock(ResourceRelation.class);
-        metricSampleBuilder = mock(MetricSampleBuilder.class);
-        sample = mock(Sample.class);
-        metricFamilySamples = mock(MetricFamilySamples.class);
-        resourceTagHelper = mock(ResourceTagHelper.class);
-        tagUtil = mock(TagUtil.class);
         mockLabels = mock(Labels.class);
-        rateLimiter = new RateLimiter(metricCollector);
+        ecsTaskProvider = mock(ECSTaskProvider.class);
         resetAll();
     }
 
@@ -137,9 +77,8 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
                 .build());
         replayAll();
         ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil) {
+                restTemplate, accountProvider, scrapeConfigProvider, resourceMapper, ecsTaskUtil, objectMapperFactory,
+                ecsTaskProvider) {
             @Override
             String getMetaDataURI() {
                 return "http://localhost";
@@ -160,9 +99,8 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
         expect(scrapeConfig.getPrimaryExporterByAccount()).andReturn(ImmutableMap.of()).anyTimes();
         replayAll();
         ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil);
+                restTemplate, accountProvider, scrapeConfigProvider,
+                resourceMapper, ecsTaskUtil, objectMapperFactory, ecsTaskProvider);
 
         testClass.getSubnetDetails().set(SubnetDetails.builder()
                 .vpcId("vpc-id")
@@ -180,9 +118,8 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
                 SubnetDetails.builder().vpcId("vpc-id").build())).anyTimes();
         replayAll();
         ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil);
+                restTemplate, accountProvider, scrapeConfigProvider,
+                resourceMapper, ecsTaskUtil, objectMapperFactory, ecsTaskProvider);
 
         testClass.getSubnetDetails().set(SubnetDetails.builder()
                 .vpcId("vpc-id")
@@ -200,9 +137,8 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
                 SubnetDetails.builder().subnetId("subnet-id").build())).anyTimes();
         replayAll();
         ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil);
+                restTemplate, accountProvider, scrapeConfigProvider,
+                resourceMapper, ecsTaskUtil, objectMapperFactory, ecsTaskProvider);
 
         testClass.getSubnetDetails().set(SubnetDetails.builder()
                 .vpcId("vpc-id")
@@ -220,9 +156,8 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
                 SubnetDetails.builder().vpcId("vpc-id").build())).anyTimes();
         replayAll();
         ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil);
+                restTemplate, accountProvider, scrapeConfigProvider,
+                resourceMapper, ecsTaskUtil, objectMapperFactory, ecsTaskProvider);
 
         testClass.getSubnetDetails().set(SubnetDetails.builder()
                 .vpcId("vpc-id1")
@@ -240,9 +175,8 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
                 SubnetDetails.builder().subnetId("subnet-id").build())).anyTimes();
         replayAll();
         ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil);
+                restTemplate, accountProvider, scrapeConfigProvider,
+                resourceMapper, ecsTaskUtil, objectMapperFactory, ecsTaskProvider);
 
         testClass.getSubnetDetails().set(SubnetDetails.builder()
                 .vpcId("vpc-id")
@@ -260,9 +194,8 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
 
         replayAll();
         ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil) {
+                restTemplate, accountProvider, scrapeConfigProvider,
+                resourceMapper, ecsTaskUtil, objectMapperFactory, ecsTaskProvider) {
             @Override
             void identifySubnetsToScrape() {
                 super.subnetsToScrape.add("subnet-1");
@@ -276,10 +209,10 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
                 .subnetId("subnet-1")
                 .build());
         assertTrue(testClass.shouldScrapeTargets(scrapeConfig, StaticConfig.builder()
-                        .labels(Labels.builder()
-                                .vpcId("vpc-1")
-                                .subnetId("subnet-1")
-                                .build())
+                .labels(Labels.builder()
+                        .vpcId("vpc-1")
+                        .subnetId("subnet-1")
+                        .build())
                 .build()));
 
         // Same VPC, different subnet. But subnet configured to be scraped
@@ -309,475 +242,36 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
     }
 
     @Test
-    public void updateCollect() throws Exception {
-        expect(accountProvider.getAccounts()).andReturn(ImmutableSet.of(account));
+    public void run() throws Exception {
         expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
         expect(scrapeConfig.getEcsTargetSDFile()).andReturn("ecs-sd-file.yml");
-        expect(scrapeConfig.getEcsTaskScrapeConfigs()).andReturn(ImmutableList.of());
         expect(scrapeConfig.isDiscoverECSTasks()).andReturn(true);
+
+        expect(ecsTaskProvider.getScrapeTargets()).andReturn(ImmutableList.of(mockStaticConfig, mockStaticConfig));
+
         expect(scrapeConfig.isLogECSTargets()).andReturn(true);
         expect(mockStaticConfig.getLabels()).andReturn(mockLabels).anyTimes();
-        expect(scrapeConfig.keepMetric("up", mockLabels)).andReturn(true).times(3);
-        expect(scrapeConfig.keepMetric("up", mockLabels)).andReturn(false);
-        expect(scrapeConfig.isDiscoverECSTasksAcrossVPCs()).andReturn(true).anyTimes();
-        expect(scrapeConfig.isDiscoverOnlySubnetTasks()).andReturn(false).anyTimes();
         expect(mockLabels.getVpcId()).andReturn("vpc-id").anyTimes();
         expect(mockLabels.getSubnetId()).andReturn("subnet-id").anyTimes();
 
-        expect(awsClientProvider.getECSClient("region1", account)).andReturn(ecsClient);
-        expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
-                .clusterArns("arn1", "arn2")
-                .build());
-        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
-        expect(resourceMapper.map("arn1")).andReturn(Optional.of(resource));
-        expect(resourceMapper.map("arn2")).andReturn(Optional.of(resource));
-
-        expect(awsClientProvider.getECSClient("region2", account)).andReturn(ecsClient);
-        expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
-                .clusterArns("arn3", "arn4")
-                .build());
-        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
-        expect(resourceMapper.map("arn3")).andReturn(Optional.of(resource));
-        expect(resourceMapper.map("arn4")).andReturn(Optional.of(resource));
-        expectLastCall();
 
         expect(objectMapperFactory.getObjectMapper()).andReturn(objectMapper);
         expect(objectMapper.writerWithDefaultPrettyPrinter()).andReturn(objectWriter);
 
         objectWriter.writeValue(anyObject(File.class), eq(ImmutableList.of(
-                mockStaticConfig, mockStaticConfig, mockStaticConfig
+                mockStaticConfig, mockStaticConfig
         )));
 
         expect(objectWriter.writeValueAsString(eq(ImmutableList.of(
-                mockStaticConfig, mockStaticConfig, mockStaticConfig
+                mockStaticConfig, mockStaticConfig
         )))).andReturn("content");
 
-        expect(metricSampleBuilder.buildFamily(ImmutableList.of(sample, sample, sample, sample)))
-                .andReturn(Optional.of(metricFamilySamples));
-
         replayAll();
         ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil) {
-            @Override
-            String getMetaDataURI() {
-                return "http://localhost";
-            }
-
-            @Override
-            List<StaticConfig> buildTargetsInCluster(AWSAccount account, ScrapeConfig sc, EcsClient client,
-                                                     Resource _cluster,
-                                                     Set<ResourceRelation> routing,
-                                                     List<Sample> taskMetaMetric) {
-                assertEquals(scrapeConfig, sc);
-                assertEquals(ecsClient, client);
-                assertEquals(resource, _cluster);
-                taskMetaMetric.add(sample);
-                return ImmutableList.of(mockStaticConfig);
-            }
-        };
+                restTemplate, accountProvider, scrapeConfigProvider,
+                resourceMapper, ecsTaskUtil, objectMapperFactory, ecsTaskProvider);
         testClass.getSubnetDetails().set(SubnetDetails.builder().vpcId("vpc-id").subnetId("subnet-id").build());
-        testClass.update();
-        assertEquals(ImmutableList.of(metricFamilySamples), testClass.collect());
-
-        verifyAll();
-    }
-
-    @Test
-    public void update_JacksonWriteException() throws Exception {
-        expect(accountProvider.getAccounts()).andReturn(ImmutableSet.of(account));
-        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
-        expect(scrapeConfig.getEcsTaskScrapeConfigs()).andReturn(ImmutableList.of());
-        expect(scrapeConfig.getEcsTargetSDFile()).andReturn("ecs-sd-file.yml");
-        expect(scrapeConfig.isDiscoverECSTasks()).andReturn(true);
-        expect(mockStaticConfig.getLabels()).andReturn(mockLabels).anyTimes();
-        expect(scrapeConfig.keepMetric("up", mockLabels)).andReturn(true).times(3);
-        expect(scrapeConfig.keepMetric("up", mockLabels)).andReturn(false);
-
-        expect(scrapeConfig.isDiscoverECSTasksAcrossVPCs()).andReturn(true).anyTimes();
-        expect(scrapeConfig.isDiscoverOnlySubnetTasks()).andReturn(false).anyTimes();
-        expect(mockLabels.getVpcId()).andReturn("vpc-id").anyTimes();
-        expect(mockLabels.getSubnetId()).andReturn("subnet-id").anyTimes();
-
-        expect(awsClientProvider.getECSClient("region1", account)).andReturn(ecsClient);
-        expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
-                .clusterArns("arn1", "arn2")
-                .build());
-        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
-        expect(resourceMapper.map("arn1")).andReturn(Optional.of(resource));
-        expect(resourceMapper.map("arn2")).andReturn(Optional.of(resource));
-
-        expect(awsClientProvider.getECSClient("region2", account)).andReturn(ecsClient);
-        expect(ecsClient.listClusters()).andReturn(ListClustersResponse.builder()
-                .clusterArns("arn3", "arn4")
-                .build());
-        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
-        expect(resourceMapper.map("arn3")).andReturn(Optional.of(resource));
-        expect(resourceMapper.map("arn4")).andReturn(Optional.of(resource));
-        expectLastCall();
-
-        expect(objectMapperFactory.getObjectMapper()).andReturn(objectMapper);
-        expect(objectMapper.writerWithDefaultPrettyPrinter()).andReturn(objectWriter);
-
-        objectWriter.writeValue(anyObject(File.class), eq(ImmutableList.of(
-                mockStaticConfig, mockStaticConfig, mockStaticConfig
-        )));
-        expectLastCall().andThrow(new IOException());
-
-        replayAll();
-        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter, lbToECSRoutingBuilder,
-                metricSampleBuilder, resourceTagHelper, tagUtil) {
-            String getMetaDataURI() {
-                return "http://localhost";
-            }
-
-            @Override
-            List<StaticConfig> buildTargetsInCluster(AWSAccount awsAccount, ScrapeConfig sc, EcsClient client,
-                                                     Resource _cluster,
-                                                     Set<ResourceRelation> routing,
-                                                     List<Sample> taskMetaMetric) {
-                assertEquals(scrapeConfig, sc);
-                assertEquals(ecsClient, client);
-                assertEquals(resource, _cluster);
-                return ImmutableList.of(mockStaticConfig);
-            }
-        };
-        testClass.getSubnetDetails().set(SubnetDetails.builder().vpcId("vpc-id").subnetId("subnet-id").build());
-        testClass.update();
-
-        verifyAll();
-    }
-
-    @Test
-    public void update_AWSException() throws Exception {
-        expect(accountProvider.getAccounts()).andReturn(ImmutableSet.of(account));
-        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
-        expect(scrapeConfig.getEcsTaskScrapeConfigs()).andReturn(ImmutableList.of());
-        expect(scrapeConfig.getEcsTargetSDFile()).andReturn("ecs-sd-file.yml");
-        expect(scrapeConfig.isDiscoverECSTasks()).andReturn(true);
-        expect(scrapeConfig.isLogECSTargets()).andReturn(true);
-
-        expect(scrapeConfig.isDiscoverOnlySubnetTasks()).andReturn(true).anyTimes();
-        expect(mockLabels.getVpcId()).andReturn("vpc-id").anyTimes();
-        expect(mockLabels.getSubnetId()).andReturn("subnet-id").anyTimes();
-
-        expect(awsClientProvider.getECSClient("region1", account)).andReturn(ecsClient);
-        expect(ecsClient.listClusters()).andThrow(new RuntimeException());
-        metricCollector.recordLatency(anyString(), anyObject(), anyLong());
-        metricCollector.recordCounterValue(eq(SCRAPE_ERROR_COUNT_METRIC), anyObject(), eq(1));
-
-        expect(awsClientProvider.getECSClient("region2", account)).andReturn(ecsClient);
-        expect(ecsClient.listClusters()).andThrow(new RuntimeException());
-        metricCollector.recordLatency(anyString(), anyObject(), anyLong());
-        metricCollector.recordCounterValue(eq(SCRAPE_ERROR_COUNT_METRIC), anyObject(), eq(1));
-
-        expect(objectMapperFactory.getObjectMapper()).andReturn(objectMapper);
-        expect(objectMapper.writerWithDefaultPrettyPrinter()).andReturn(objectWriter);
-        objectWriter.writeValue(anyObject(File.class), eq(ImmutableList.of()));
-        expect(objectWriter.writeValueAsString(eq(ImmutableList.of()))).andReturn("content");
-        expectLastCall();
-
-        replayAll();
-        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil) {
-            String getMetaDataURI() {
-                return "http://localhost";
-            }
-        };
-        testClass.getSubnetDetails().set(SubnetDetails.builder().vpcId("vpc-id").subnetId("subnet-id").build());
-        testClass.update();
-
-        verifyAll();
-    }
-
-    @Test
-    public void buildTargetsInCluster() {
-        Set<ResourceRelation> newRouting = new HashSet<>();
-        List<Sample> samples = new ArrayList<>();
-        expect(scrapeConfig.isDiscoverECSTasks()).andReturn(true).anyTimes();
-        expect(scrapeConfig.getECSConfigByNameAndPort()).andReturn(ImmutableSortedMap.of()).anyTimes();
-        Resource cluster = Resource.builder()
-                .region("region1")
-                .arn("arn1")
-                .name("cluster")
-                .account("account")
-                .type(ECSCluster)
-                .build();
-        expect(ecsClient.listServices(ListServicesRequest.builder()
-                .cluster(cluster.getName())
-                .build()))
-                .andReturn(ListServicesResponse.builder()
-                        .serviceArns("arn1", "arn2")
-                        .build());
-        expect(resourceMapper.map("arn1")).andReturn(Optional.of(resource)).times(2);
-        expect(resourceMapper.map("arn2")).andReturn(Optional.of(resource)).times(2);
-
-        expect(ecsClient.listTasks(ListTasksRequest.builder()
-                .cluster(cluster.getName())
-                .build()))
-                .andReturn(ListTasksResponse.builder()
-                        .taskArns("taskArn1")
-                        .build());
-
-        expect(resourceMapper.map("taskArn1")).andReturn(Optional.of(Resource.builder()
-                .account("account")
-                .region("region")
-                .name("task1")
-                .childOf(Resource.builder()
-                        .name("cluster")
-                        .build())
-                .build()));
-
-        // List tasks in service
-        metricCollector.recordLatency(anyString(), anyObject(), anyLong());
-
-        // For listTasks
-        metricCollector.recordLatency(anyString(), anyObject(), anyLong());
-
-        expect(lbToECSRoutingBuilder.getRoutings(ecsClient, cluster, ImmutableList.of(resource, resource)))
-                .andReturn(ImmutableSet.of(mockRelation));
-
-        expect(resource.getName()).andReturn("s1");
-        expect(resource.getName()).andReturn("s2");
-
-        expect(resourceTagHelper.getResourcesWithTag(anyObject(AWSAccount.class), eq("region1"), eq("ecs:service"),
-                eq(ImmutableList.of("s1", "s2")))).andReturn(ImmutableMap.of("s1", resource, "s2", resource));
-
-        expect(mockStaticConfig.getLabels()).andReturn(Labels.builder()
-                .accountId("account")
-                .region("region")
-                .cluster("cluster")
-                .pod("workload-task2")
-                .workload("workload")
-                .build()).anyTimes();
-
-        replayAll();
-        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(restTemplate, accountProvider,
-                scrapeConfigProvider, awsClientProvider, resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil) {
-            String getMetaDataURI() {
-                return "http://localhost";
-            }
-
-            @Override
-            List<StaticConfig> buildTargetsInService(ScrapeConfig sc, EcsClient client, Resource _cluster,
-                                                     Resource _service, Map<String, Resource> tagsByName,
-                                                     List<Sample> taskMetaMetric) {
-                assertEquals(scrapeConfig, sc);
-                assertEquals(ecsClient, client);
-                assertEquals(cluster, _cluster);
-                return ImmutableList.of(mockStaticConfig);
-            }
-
-            @Override
-            List<StaticConfig> buildTaskTargets(ScrapeConfig sc, EcsClient client, Resource _cluster,
-                                                Optional<Resource> service, Set<String> taskARNs,
-                                                Map<String, String> tags,
-                                                List<Sample> taskMetaMetric) {
-                assertEquals(scrapeConfig, sc);
-                assertEquals(ecsClient, client);
-                assertFalse(service.isPresent());
-                assertEquals(ImmutableSet.of("taskArn1"), taskARNs);
-                return ImmutableList.of(mockStaticConfig);
-            }
-        };
-        testClass.getSubnetDetails().set(new SubnetDetails());
-        assertEquals(
-                ImmutableList.of(mockStaticConfig, mockStaticConfig, mockStaticConfig),
-                testClass.buildTargetsInCluster(account, scrapeConfig, ecsClient, cluster, newRouting, samples));
-
-        assertEquals(ImmutableSet.of(mockRelation), newRouting);
-
-        verifyAll();
-    }
-
-    @Test
-    public void buildTargetsInService() {
-        List<Sample> taskMetaSamples = new ArrayList<>();
-        Resource cluster = Resource.builder()
-                .region("region1")
-                .arn("cluster-arn")
-                .name("cluster")
-                .account("account")
-                .type(ECSCluster)
-                .build();
-
-        Resource service = Resource.builder()
-                .region("region1")
-                .arn("service-arn")
-                .name("service")
-                .account("account")
-                .type(ECSService)
-                .childOf(cluster)
-                .build();
-
-        List<String> taskArns = new ArrayList<>();
-        for (int i = 0; i < 101; i++) {
-            taskArns.add("arn" + i);
-        }
-
-        List<Set<String>> expectedARNs = new ArrayList<>();
-        expectedARNs.add(Sets.newHashSet(taskArns.subList(0, 100)));
-        expectedARNs.add(Sets.newHashSet(taskArns.subList(100, 101)));
-        expect(ecsClient.listTasks(ListTasksRequest.builder()
-                .cluster(cluster.getName())
-                .serviceName(service.getName())
-                .build()))
-                .andReturn(ListTasksResponse.builder()
-                        .nextToken("token1")
-                        .taskArns(expectedARNs.get(0))
-                        .build());
-        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
-
-        expect(ecsClient.listTasks(ListTasksRequest.builder()
-                .cluster(cluster.getName())
-                .serviceName(service.getName())
-                .nextToken("token1")
-                .build()))
-                .andReturn(ListTasksResponse.builder()
-                        .taskArns(expectedARNs.get(1))
-                        .build());
-        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(), anyLong());
-
-        List<Set<String>> actualARNs = new ArrayList<>();
-
-        replayAll();
-        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter,
-                lbToECSRoutingBuilder, metricSampleBuilder, resourceTagHelper, tagUtil) {
-            String getMetaDataURI() {
-                return "http://localhost";
-            }
-
-            @Override
-            List<StaticConfig> buildTaskTargets(ScrapeConfig sc, EcsClient client, Resource _cluster,
-                                                Optional<Resource> _service, Set<String> taskIds,
-                                                Map<String, String> tagLabels,
-                                                List<Sample> taskMetaMetric) {
-                assertEquals(scrapeConfig, sc);
-                assertEquals(ecsClient, client);
-                assertEquals(cluster, _cluster);
-                assertEquals(Optional.of(service), _service);
-                actualARNs.add(taskIds);
-                return ImmutableList.of(mockStaticConfig);
-            }
-        };
-        assertEquals(
-                ImmutableList.of(mockStaticConfig, mockStaticConfig),
-                testClass.buildTargetsInService(scrapeConfig, ecsClient, cluster, service, Collections.emptyMap(),
-                        taskMetaSamples));
-        assertEquals(expectedARNs, actualARNs);
-
-        verifyAll();
-    }
-
-    @Test
-    public void buildTaskTargets() {
-        List<Sample> taskMetaSamples = new ArrayList<>();
-        Resource cluster = Resource.builder()
-                .region("region1")
-                .arn("cluster-arn")
-                .name("cluster")
-                .account("account")
-                .type(ECSCluster)
-                .build();
-
-        Resource service = Resource.builder()
-                .region("region1")
-                .arn("service-arn")
-                .name("service")
-                .account("account")
-                .type(ECSService)
-                .childOf(cluster)
-                .build();
-
-        Set<String> taskArns = new LinkedHashSet<>();
-        for (int i = 0; i < 2; i++) {
-            taskArns.add("arn" + i);
-        }
-
-        Task task1 = Task.builder()
-                .taskArn("arn1")
-                .taskDefinitionArn("taskdef-arn1")
-                .version(1L)
-                .build();
-        Task task2 = Task.builder()
-                .taskArn("arn2")
-                .taskDefinitionArn("taskdef-arn2")
-                .group("group")
-                .version(2L)
-                .build();
-
-        expect(resourceMapper.map("taskdef-arn1")).andReturn(Optional.of(resource));
-        expect(resource.getName()).andReturn("taskdef1");
-        expect(resourceMapper.map("arn1")).andReturn(Optional.of(resource));
-        expect(resource.getName()).andReturn("task1");
-
-        expect(metricSampleBuilder.buildSingleSample("aws_ecs_task_info",
-                ImmutableMap.<String, String>builder()
-                        .put("account_id", "account")
-                        .put("region", "region1")
-                        .put("cluster", "cluster")
-                        .put("service", "service")
-                        .put("task_id", "task1")
-                        .put("taskdef_family", "taskdef1")
-                        .put("taskdef_version", "1")
-                        .build(), 1.0D)).andReturn(Optional.of(sample));
-
-        expect(resourceMapper.map("taskdef-arn2")).andReturn(Optional.of(resource));
-        expect(resource.getName()).andReturn("taskdef2");
-        expect(resourceMapper.map("arn2")).andReturn(Optional.of(resource));
-        expect(resource.getName()).andReturn("task2");
-
-        expect(metricSampleBuilder.buildSingleSample("aws_ecs_task_info",
-                ImmutableMap.<String, String>builder()
-                        .put("account_id", "account")
-                        .put("region", "region1")
-                        .put("cluster", "cluster")
-                        .put("service", "service")
-                        .put("task_id", "task2")
-                        .put("taskdef_family", "taskdef2")
-                        .put("taskdef_version", "2")
-                        .build(), 1.0D)).andReturn(Optional.of(sample));
-
-        expect(ecsClient.describeTasks(DescribeTasksRequest.builder()
-                .cluster(cluster.getName())
-                .tasks(taskArns)
-                .build())).andReturn(DescribeTasksResponse.builder()
-                .tasks(task1, task2)
-                .build());
-        metricCollector.recordLatency(anyString(), anyObject(), anyLong());
-
-        expect(ecsTaskUtil.hasAllInfo(task1)).andReturn(true);
-        expect(ecsTaskUtil.hasAllInfo(task2)).andReturn(true);
-
-        expect(ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster, Optional.of(service), task1,
-                Collections.emptyMap()))
-                .andReturn(ImmutableList.of(mockStaticConfig));
-
-        expect(ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster, Optional.of(service), task2,
-                Collections.emptyMap()))
-                .andReturn(ImmutableList.of(mockStaticConfig));
-
-        replayAll();
-        ECSServiceDiscoveryExporter testClass = new ECSServiceDiscoveryExporter(
-                restTemplate, accountProvider, scrapeConfigProvider, awsClientProvider,
-                resourceMapper, ecsTaskUtil, objectMapperFactory, rateLimiter, lbToECSRoutingBuilder,
-                metricSampleBuilder, resourceTagHelper, tagUtil) {
-            String getMetaDataURI() {
-                return "http://localhost";
-            }
-        };
-        assertEquals(
-                ImmutableList.of(mockStaticConfig, mockStaticConfig),
-                testClass.buildTaskTargets(scrapeConfig, ecsClient, cluster, Optional.of(service), taskArns,
-                        Collections.emptyMap(), taskMetaSamples));
+        testClass.run();
 
         verifyAll();
     }

--- a/src/test/java/ai/asserts/aws/exporter/ECSTaskProviderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSTaskProviderTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.ecs.model.DescribeTasksRequest;
 import software.amazon.awssdk.services.ecs.model.DescribeTasksResponse;
+import software.amazon.awssdk.services.ecs.model.DesiredStatus;
 import software.amazon.awssdk.services.ecs.model.ListTasksRequest;
 import software.amazon.awssdk.services.ecs.model.ListTasksResponse;
 import software.amazon.awssdk.services.ecs.model.Task;
@@ -214,6 +215,7 @@ public class ECSTaskProviderTest extends EasyMockSupport {
 
         expect(ecsClient.listTasks(ListTasksRequest.builder()
                 .cluster("cluster1")
+                .desiredStatus(DesiredStatus.RUNNING)
                 .build()))
                 .andReturn(
                         ListTasksResponse.builder()
@@ -225,6 +227,7 @@ public class ECSTaskProviderTest extends EasyMockSupport {
         expect(ecsClient.listTasks(ListTasksRequest.builder()
                 .cluster("cluster1")
                 .nextToken("token1")
+                .desiredStatus(DesiredStatus.RUNNING)
                 .build()))
                 .andReturn(
                         ListTasksResponse.builder()
@@ -288,8 +291,8 @@ public class ECSTaskProviderTest extends EasyMockSupport {
                 .build())).andReturn(DescribeTasksResponse.builder()
                 .tasks(task1, task2)
                 .build());
-        expect(ecsTaskUtil.hasAllInfo(task1)).andReturn(true).times(3);
-        expect(ecsTaskUtil.hasAllInfo(task2)).andReturn(true).times(3);
+        expect(ecsTaskUtil.hasAllInfo(task1)).andReturn(true).times(2);
+        expect(ecsTaskUtil.hasAllInfo(task2)).andReturn(true).times(2);
         basicMetricCollector.recordLatency(eq("aws_exporter_milliseconds"), anyObject(SortedMap.class), anyLong());
 
         Resource task1Resource = Resource.builder().name("task1").build();
@@ -317,8 +320,8 @@ public class ECSTaskProviderTest extends EasyMockSupport {
                 .tasks(task3, task4)
                 .build());
 
-        expect(ecsTaskUtil.hasAllInfo(task3)).andReturn(true).times(3);
-        expect(ecsTaskUtil.hasAllInfo(task4)).andReturn(true).times(3);
+        expect(ecsTaskUtil.hasAllInfo(task3)).andReturn(true).times(2);
+        expect(ecsTaskUtil.hasAllInfo(task4)).andReturn(true).times(2);
 
         Resource task3Resource = Resource.builder().name("task3").build();
         Resource task4Resource = Resource.builder().name("task4").build();

--- a/src/test/java/ai/asserts/aws/exporter/ECSTaskProviderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSTaskProviderTest.java
@@ -1,0 +1,352 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import ai.asserts.aws.AWSClientProvider;
+import ai.asserts.aws.AccountProvider;
+import ai.asserts.aws.AccountProvider.AWSAccount;
+import ai.asserts.aws.RateLimiter;
+import ai.asserts.aws.ScrapeConfigProvider;
+import ai.asserts.aws.config.ScrapeConfig;
+import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
+import ai.asserts.aws.resource.Resource;
+import ai.asserts.aws.resource.ResourceMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.prometheus.client.Collector;
+import io.prometheus.client.Collector.MetricFamilySamples.Sample;
+import io.prometheus.client.CollectorRegistry;
+import org.easymock.EasyMockSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ecs.EcsClient;
+import software.amazon.awssdk.services.ecs.model.DescribeTasksRequest;
+import software.amazon.awssdk.services.ecs.model.DescribeTasksResponse;
+import software.amazon.awssdk.services.ecs.model.ListTasksRequest;
+import software.amazon.awssdk.services.ecs.model.ListTasksResponse;
+import software.amazon.awssdk.services.ecs.model.Task;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
+
+import static ai.asserts.aws.exporter.ECSTaskProvider.TASK_META_METRIC;
+import static org.easymock.EasyMock.anyLong;
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.eq;
+import static org.easymock.EasyMock.expect;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ECSTaskProviderTest extends EasyMockSupport {
+    private AWSClientProvider awsClientProvider;
+    private ScrapeConfigProvider scrapeConfigProvider;
+    private ScrapeConfig scrapeConfig;
+    private AccountProvider accountProvider;
+    private BasicMetricCollector basicMetricCollector;
+    private ResourceMapper resourceMapper;
+    private ECSClusterProvider ecsClusterProvider;
+    private ECSTaskUtil ecsTaskUtil;
+    private MetricSampleBuilder sampleBuilder;
+    private Sample mockSample;
+    private Collector.MetricFamilySamples mockFamilySamples;
+
+    private CollectorRegistry collectorRegistry;
+    private EcsClient ecsClient;
+
+    private StaticConfig mockStaticConfig;
+    private ECSTaskProvider testClass;
+
+    @BeforeEach
+    public void setup() {
+        awsClientProvider = mock(AWSClientProvider.class);
+        scrapeConfigProvider = mock(ScrapeConfigProvider.class);
+        scrapeConfig = mock(ScrapeConfig.class);
+        accountProvider = mock(AccountProvider.class);
+        basicMetricCollector = mock(BasicMetricCollector.class);
+        resourceMapper = mock(ResourceMapper.class);
+        ecsClusterProvider = mock(ECSClusterProvider.class);
+        ecsTaskUtil = mock(ECSTaskUtil.class);
+        sampleBuilder = mock(MetricSampleBuilder.class);
+        collectorRegistry = mock(CollectorRegistry.class);
+        ecsClient = mock(EcsClient.class);
+        mockStaticConfig = mock(StaticConfig.class);
+        mockSample = mock(Sample.class);
+        mockFamilySamples = mock(Collector.MetricFamilySamples.class);
+        testClass = new ECSTaskProvider(awsClientProvider, scrapeConfigProvider, accountProvider,
+                new RateLimiter(basicMetricCollector), resourceMapper, ecsClusterProvider, ecsTaskUtil, sampleBuilder,
+                collectorRegistry);
+    }
+
+
+    @Test
+    public void afterPropertiesSet() throws Exception {
+        collectorRegistry.register(testClass);
+        replayAll();
+        testClass.afterPropertiesSet();
+        verifyAll();
+    }
+
+    @Test
+    public void collect() throws Exception {
+        Resource cluster1 = Resource.builder()
+                .name("cluster1")
+                .region("region")
+                .account("account1")
+                .arn("cluster1-arn")
+                .build();
+
+
+        Resource task1 = Resource.builder()
+                .name("task1")
+                .build();
+
+        Map<Resource, Map<Resource, List<StaticConfig>>> tasksByCluster = testClass.getTasksByCluster();
+        tasksByCluster.put(cluster1, ImmutableMap.of(task1, ImmutableList.of(mockStaticConfig, mockStaticConfig)));
+
+        Labels labels1 = Labels.builder()
+                .vpcId("vpc-1")
+                .build();
+        expect(mockStaticConfig.getLabels()).andReturn(labels1);
+        expect(sampleBuilder.buildSingleSample(TASK_META_METRIC, labels1, 1.0D))
+                .andReturn(Optional.of(mockSample));
+
+        Labels labels2 = Labels.builder()
+                .vpcId("vpc-1")
+                .build();
+        expect(mockStaticConfig.getLabels()).andReturn(labels2);
+        expect(sampleBuilder.buildSingleSample(TASK_META_METRIC, labels2, 1.0D))
+                .andReturn(Optional.of(mockSample));
+
+        expect(sampleBuilder.buildFamily(ImmutableList.of(mockSample, mockSample))).andReturn(
+                Optional.of(mockFamilySamples));
+
+        replayAll();
+        assertEquals(ImmutableList.of(mockFamilySamples), testClass.collect());
+        verifyAll();
+    }
+
+    @Test
+    public void getService() {
+        assertEquals(Optional.empty(), testClass.getService(Task.builder()
+                .group("task-family-name")
+                .build()));
+        assertEquals(Optional.of("service-name"), testClass.getService(Task.builder()
+                .group("service:service-name")
+                .build()));
+    }
+
+    @Test
+    public void getScrapeTargets() {
+        AWSAccount awsAccount = AWSAccount.builder()
+                .accountId("account1")
+                .regions(ImmutableSet.of("region"))
+                .name("test-account")
+                .build();
+
+        Resource cluster1 = Resource.builder()
+                .name("cluster1")
+                .region("region")
+                .account("account1")
+                .arn("cluster1-arn")
+                .build();
+
+        Resource task1 = Resource.builder()
+                .name("task1")
+                .build();
+
+        testClass = new ECSTaskProvider(awsClientProvider, scrapeConfigProvider, accountProvider,
+                new RateLimiter(basicMetricCollector), resourceMapper, ecsClusterProvider, ecsTaskUtil, sampleBuilder,
+                collectorRegistry) {
+            @Override
+            void discoverNewTasks(Map<Resource, List<Resource>> clusterWiseNewTasks, EcsClient ecsClient,
+                                  Resource cluster) {
+                assertEquals(cluster1, cluster);
+                clusterWiseNewTasks.put(cluster1, ImmutableList.of(task1));
+            }
+
+            @Override
+            void buildNewTargets(AWSAccount _account, ScrapeConfig _scrapeConfig,
+                                 Map<Resource, List<Resource>> clusterWiseNewTasks,
+                                 EcsClient ecsClient) {
+                assertEquals(awsAccount, _account);
+                assertEquals(scrapeConfig, _scrapeConfig);
+                assertEquals(ImmutableMap.of(cluster1, ImmutableList.of(task1)), clusterWiseNewTasks);
+            }
+        };
+
+        testClass.getTasksByCluster().put(cluster1, ImmutableMap.of(task1, ImmutableList.of(mockStaticConfig)));
+
+        expect(scrapeConfigProvider.getScrapeConfig()).andReturn(scrapeConfig);
+
+        expect(accountProvider.getAccounts()).andReturn(ImmutableSet.of(awsAccount));
+        expect(awsClientProvider.getECSClient("region", awsAccount)).andReturn(ecsClient);
+        expect(ecsClusterProvider.getClusters(awsAccount, "region")).andReturn(ImmutableSet.of(cluster1));
+        replayAll();
+        assertEquals(ImmutableList.of(mockStaticConfig), testClass.getScrapeTargets());
+        verifyAll();
+    }
+
+    @Test
+    public void discoverNewTargets() {
+        Resource cluster1 = Resource.builder()
+                .name("cluster1")
+                .region("region")
+                .account("account1")
+                .arn("cluster1-arn")
+                .build();
+
+        Resource task1Resource = Resource.builder().name("task1").build();
+        Resource task2Resource = Resource.builder().name("task2").build();
+        Resource task3Resource = Resource.builder().name("task3").build();
+
+        HashMap<Resource, List<StaticConfig>> byTask = new HashMap<>();
+        byTask.put(task1Resource, ImmutableList.of(mockStaticConfig));
+        byTask.put(task2Resource, ImmutableList.of(mockStaticConfig));
+        testClass.getTasksByCluster().put(cluster1, byTask);
+
+
+        expect(ecsClient.listTasks(ListTasksRequest.builder()
+                .cluster("cluster1")
+                .build()))
+                .andReturn(
+                        ListTasksResponse.builder()
+                                .nextToken("token1")
+                                .taskArns(ImmutableList.of("task2-arn"))
+                                .build());
+        basicMetricCollector.recordLatency(eq("aws_exporter_milliseconds"), anyObject(SortedMap.class), anyLong());
+
+        expect(ecsClient.listTasks(ListTasksRequest.builder()
+                .cluster("cluster1")
+                .nextToken("token1")
+                .build()))
+                .andReturn(
+                        ListTasksResponse.builder()
+                                .nextToken("token1")
+                                .taskArns(ImmutableList.of("task3-arn"))
+                                .build());
+        basicMetricCollector.recordLatency(eq("aws_exporter_milliseconds"), anyObject(SortedMap.class), anyLong());
+
+        expect(resourceMapper.map("task2-arn")).andReturn(Optional.of(task2Resource));
+        expect(resourceMapper.map("task3-arn")).andReturn(Optional.of(task3Resource));
+
+        replayAll();
+
+        HashMap<Resource, List<Resource>> clusterWiseNewTasks = new HashMap<>();
+        testClass.discoverNewTasks(clusterWiseNewTasks, ecsClient, cluster1);
+        assertFalse(clusterWiseNewTasks.isEmpty());
+        assertTrue(clusterWiseNewTasks.containsKey(cluster1));
+        assertEquals(ImmutableList.of(task3Resource), clusterWiseNewTasks.get(cluster1));
+
+        assertFalse(byTask.containsKey(task1Resource));
+        assertTrue(byTask.containsKey(task2Resource));
+        verifyAll();
+    }
+
+    @Test
+    public void buildNewTargets() {
+        Resource cluster1 = Resource.builder()
+                .name("cluster1")
+                .region("region")
+                .account("account1")
+                .arn("cluster1-arn")
+                .build();
+        Resource service1 = Resource.builder().arn("service1-arn").build();
+        Resource service2 = Resource.builder().arn("service2-arn").build();
+
+        Resource cluster2 = Resource.builder()
+                .name("cluster2")
+                .region("region")
+                .account("account1")
+                .arn("cluster2-arn")
+                .build();
+        Resource service3 = Resource.builder().arn("service3-arn").build();
+        Resource service4 = Resource.builder().arn("service4-arn").build();
+
+        Map<Resource, List<Resource>> clusterWiseARNs = new HashMap<>();
+
+        clusterWiseARNs.put(cluster1, ImmutableList.of(service1, service2));
+        clusterWiseARNs.put(cluster2, ImmutableList.of(service3, service4));
+
+        Task task1 = Task.builder()
+                .group("service:service1")
+                .taskArn("service1-task1-arn")
+                .build();
+        Task task2 = Task.builder()
+                .group("service:service2")
+                .taskArn("service2-task2-arn")
+                .build();
+        expect(ecsClient.describeTasks(DescribeTasksRequest.builder()
+                .cluster("cluster1")
+                .tasks("service1-arn", "service2-arn")
+                .build())).andReturn(DescribeTasksResponse.builder()
+                .tasks(task1, task2)
+                .build());
+        expect(ecsTaskUtil.hasAllInfo(task1)).andReturn(true).times(3);
+        expect(ecsTaskUtil.hasAllInfo(task2)).andReturn(true).times(3);
+        basicMetricCollector.recordLatency(eq("aws_exporter_milliseconds"), anyObject(SortedMap.class), anyLong());
+
+        Resource task1Resource = Resource.builder().name("task1").build();
+        Resource task2Resource = Resource.builder().name("task2").build();
+        expect(resourceMapper.map("service1-task1-arn")).andReturn(Optional.of(task1Resource));
+        expect(resourceMapper.map("service2-task2-arn")).andReturn(Optional.of(task2Resource));
+
+        expect(ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster1, Optional.of("service1"), task1))
+                .andReturn(ImmutableList.of(mockStaticConfig));
+        expect(ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster1, Optional.of("service2"), task2))
+                .andReturn(ImmutableList.of(mockStaticConfig));
+
+        Task task3 = Task.builder()
+                .group("service:service3")
+                .taskArn("service3-task3-arn")
+                .build();
+        Task task4 = Task.builder()
+                .group("service:service4")
+                .taskArn("service4-task4-arn")
+                .build();
+        expect(ecsClient.describeTasks(DescribeTasksRequest.builder()
+                .cluster("cluster2")
+                .tasks("service3-arn", "service4-arn")
+                .build())).andReturn(DescribeTasksResponse.builder()
+                .tasks(task3, task4)
+                .build());
+
+        expect(ecsTaskUtil.hasAllInfo(task3)).andReturn(true).times(3);
+        expect(ecsTaskUtil.hasAllInfo(task4)).andReturn(true).times(3);
+
+        Resource task3Resource = Resource.builder().name("task3").build();
+        Resource task4Resource = Resource.builder().name("task4").build();
+        expect(resourceMapper.map("service3-task3-arn")).andReturn(Optional.of(task3Resource));
+        expect(resourceMapper.map("service4-task4-arn")).andReturn(Optional.of(task4Resource));
+
+        expect(ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster2, Optional.of("service3"), task3))
+                .andReturn(ImmutableList.of(mockStaticConfig));
+        expect(ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster2, Optional.of("service4"), task4))
+                .andReturn(ImmutableList.of(mockStaticConfig, mockStaticConfig));
+
+        basicMetricCollector.recordLatency(eq("aws_exporter_milliseconds"), anyObject(SortedMap.class), anyLong());
+
+        replayAll();
+        assertTrue(testClass.getTasksByCluster().isEmpty());
+        testClass.buildNewTargets(AWSAccount.builder().build(), scrapeConfig, clusterWiseARNs, ecsClient);
+        assertFalse(testClass.getTasksByCluster().isEmpty());
+
+        assertTrue(testClass.getTasksByCluster().containsKey(cluster1));
+        assertEquals(ImmutableMap.of(
+                task1Resource, ImmutableList.of(mockStaticConfig),
+                task2Resource, ImmutableList.of(mockStaticConfig)
+        ), testClass.getTasksByCluster().get(cluster1));
+        assertTrue(testClass.getTasksByCluster().containsKey(cluster2));
+        assertEquals(ImmutableMap.of(
+                task3Resource, ImmutableList.of(mockStaticConfig),
+                task4Resource, ImmutableList.of(mockStaticConfig, mockStaticConfig)
+        ), testClass.getTasksByCluster().get(cluster2));
+        verifyAll();
+    }
+}

--- a/src/test/java/ai/asserts/aws/exporter/LBToECSRoutingBuilderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/LBToECSRoutingBuilderTest.java
@@ -4,6 +4,9 @@
  */
 package ai.asserts.aws.exporter;
 
+import ai.asserts.aws.AWSClientProvider;
+import ai.asserts.aws.AccountProvider;
+import ai.asserts.aws.AccountProvider.AWSAccount;
 import ai.asserts.aws.RateLimiter;
 import ai.asserts.aws.resource.Resource;
 import ai.asserts.aws.resource.ResourceMapper;
@@ -17,6 +20,8 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.ecs.EcsClient;
 import software.amazon.awssdk.services.ecs.model.DescribeServicesRequest;
 import software.amazon.awssdk.services.ecs.model.DescribeServicesResponse;
+import software.amazon.awssdk.services.ecs.model.ListServicesRequest;
+import software.amazon.awssdk.services.ecs.model.ListServicesResponse;
 import software.amazon.awssdk.services.ecs.model.LoadBalancer;
 import software.amazon.awssdk.services.ecs.model.Service;
 
@@ -38,6 +43,9 @@ public class LBToECSRoutingBuilderTest extends EasyMockSupport {
     private ResourceMapper resourceMapper;
     private TargetGroupLBMapProvider targetGroupLBMapProvider;
 
+    private AWSClientProvider awsClientProvider;
+    private AccountProvider accountProvider;
+
     private EcsClient ecsClient;
 
     private LBToECSRoutingBuilder testClass;
@@ -49,7 +57,10 @@ public class LBToECSRoutingBuilderTest extends EasyMockSupport {
         resourceMapper = mock(ResourceMapper.class);
         targetGroupLBMapProvider = mock(TargetGroupLBMapProvider.class);
         ecsClient = mock(EcsClient.class);
-        testClass = new LBToECSRoutingBuilder(rateLimiter, resourceMapper, targetGroupLBMapProvider);
+        awsClientProvider = mock(AWSClientProvider.class);
+        accountProvider = mock(AccountProvider.class);
+        testClass = new LBToECSRoutingBuilder(rateLimiter, resourceMapper, targetGroupLBMapProvider,
+                awsClientProvider, accountProvider);
     }
 
     @Test
@@ -58,12 +69,14 @@ public class LBToECSRoutingBuilderTest extends EasyMockSupport {
                 .account(SCRAPE_ACCOUNT_ID_LABEL)
                 .region("region")
                 .arn("cluster-arn")
+                .name("cluster")
                 .build();
 
         Resource service = Resource.builder()
                 .account(SCRAPE_ACCOUNT_ID_LABEL)
                 .region("region")
                 .arn("service-arn")
+                .childOf(cluster)
                 .build();
 
         Resource tg = Resource.builder()
@@ -80,13 +93,35 @@ public class LBToECSRoutingBuilderTest extends EasyMockSupport {
 
         Map<Resource, Resource> tgToLb = ImmutableMap.of(tg, lb);
 
+        AWSAccount awsAccount = AWSAccount.builder()
+                .accountId("account-1")
+                .regions(ImmutableSet.of("region"))
+                .name("test-account")
+                .build();
+        expect(accountProvider.getAccounts()).andReturn(ImmutableSet.of(awsAccount));
+        expect(awsClientProvider.getECSClient("region", awsAccount)).andReturn(ecsClient);
+        expect(ecsClient.listServices(ListServicesRequest.builder()
+                .build())).andReturn(ListServicesResponse.builder()
+                .nextToken("token1")
+                .serviceArns("service-arn")
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(SortedMap.class), anyLong());
+
+        expect(ecsClient.listServices(ListServicesRequest.builder()
+                .nextToken("token1")
+                .build())).andReturn(ListServicesResponse.builder()
+                .nextToken("token1")
+                .build());
+        metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(SortedMap.class), anyLong());
+
         DescribeServicesRequest request = DescribeServicesRequest.builder()
-                .cluster("cluster-arn")
+                .cluster("cluster")
                 .services("service-arn")
                 .build();
 
         DescribeServicesResponse response = DescribeServicesResponse.builder()
                 .services(Service.builder()
+                        .clusterArn(cluster.getName())
                         .serviceArn("service-arn")
                         .loadBalancers(LoadBalancer.builder()
                                 .targetGroupArn("tg-arn")
@@ -94,17 +129,18 @@ public class LBToECSRoutingBuilderTest extends EasyMockSupport {
                         .build())
                 .build();
 
-
         expect(ecsClient.describeServices(request)).andReturn(response);
         metricCollector.recordLatency(eq(SCRAPE_LATENCY_METRIC), anyObject(SortedMap.class), anyLong());
-        expect(resourceMapper.map("service-arn")).andReturn(Optional.of(service)).times(2);
+        expect(resourceMapper.map("service-arn")).andReturn(Optional.of(service)).times(3);
         expect(resourceMapper.map("tg-arn")).andReturn(Optional.of(tg));
 
         expect(targetGroupLBMapProvider.getTgToLB()).andReturn(tgToLb);
 
         replayAll();
 
-        Set<ResourceRelation> routings = testClass.getRoutings(ecsClient, cluster, ImmutableList.of(service));
+        testClass.run();
+
+        Set<ResourceRelation> routings = testClass.getRouting();
 
         assertEquals(ImmutableSet.of(ResourceRelation.builder()
                 .from(lb)

--- a/src/test/java/ai/asserts/aws/exporter/PaginatorTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/PaginatorTest.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright © 2020.
+ *  Asserts, Inc. - All Rights Reserved
+ */
+package ai.asserts.aws.exporter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PaginatorTest {
+    @Test
+    void testHasNext() {
+        Paginator paginator = new Paginator();
+        assertFalse(paginator.hasNext());
+
+        paginator.nextToken("token1");
+        assertTrue(paginator.hasNext());
+
+        paginator.nextToken("token2");
+        assertTrue(paginator.hasNext());
+
+        paginator.nextToken("token2");
+        assertFalse(paginator.hasNext());
+    }
+}

--- a/src/test/java/ai/asserts/aws/exporter/ResourceRelationExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ResourceRelationExporterTest.java
@@ -24,11 +24,11 @@ import static org.easymock.EasyMock.expectLastCall;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResourceRelationExporterTest extends EasyMockSupport {
-    private ECSServiceDiscoveryExporter ecsServiceDiscoveryExporter;
     private LBToASGRelationBuilder lbToASGRelationBuilder;
     private LBToLambdaRoutingBuilder lbToLambdaRoutingBuilder;
     private EC2ToEBSVolumeExporter ec2ToEBSVolumeExporter;
     private ApiGatewayToLambdaBuilder apiGatewayToLambdaBuilder;
+    private LBToECSRoutingBuilder lbToECSRoutingBuilder;
     private MetricSampleBuilder sampleBuilder;
     private Resource fromResource;
     private Resource toResource;
@@ -38,7 +38,6 @@ public class ResourceRelationExporterTest extends EasyMockSupport {
 
     @BeforeEach
     public void setup() {
-        ecsServiceDiscoveryExporter = mock(ECSServiceDiscoveryExporter.class);
         lbToASGRelationBuilder = mock(LBToASGRelationBuilder.class);
         lbToLambdaRoutingBuilder = mock(LBToLambdaRoutingBuilder.class);
         sampleBuilder = mock(MetricSampleBuilder.class);
@@ -48,14 +47,16 @@ public class ResourceRelationExporterTest extends EasyMockSupport {
         familySamples = mock(Collector.MetricFamilySamples.class);
         ec2ToEBSVolumeExporter = mock(EC2ToEBSVolumeExporter.class);
         apiGatewayToLambdaBuilder = mock(ApiGatewayToLambdaBuilder.class);
-        testClass = new ResourceRelationExporter(ecsServiceDiscoveryExporter,
-                lbToASGRelationBuilder, lbToLambdaRoutingBuilder, ec2ToEBSVolumeExporter, apiGatewayToLambdaBuilder,
+        lbToECSRoutingBuilder = mock(LBToECSRoutingBuilder.class);
+        testClass = new ResourceRelationExporter(
+                lbToASGRelationBuilder, lbToLambdaRoutingBuilder, lbToECSRoutingBuilder, ec2ToEBSVolumeExporter,
+                apiGatewayToLambdaBuilder,
                 sampleBuilder);
     }
 
     @Test
     public void update() {
-        expect(ecsServiceDiscoveryExporter.getRouting()).andReturn(ImmutableSet.of(ResourceRelation.builder()
+        expect(lbToECSRoutingBuilder.getRouting()).andReturn(ImmutableSet.of(ResourceRelation.builder()
                 .from(fromResource)
                 .to(toResource)
                 .name("name1")


### PR DESCRIPTION
[ch15126]

* Separate class for discovering clusters.
* Exclude inactive clusters
* Cache clusters for 15 minutes
* Separate class for discovering tasks. Discover tasks in cluster directly.
* Cache Task Definition Lookups
* Reduce service discovery frequency to 15 minutes
* List Services only in LB to ECS Relationship building