### PR TITLE
Bug fixes

### DIFF
--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -202,6 +202,7 @@ public class ECSServiceDiscoveryExporter implements InitializingBean, Runnable {
     @Builder
     @Getter
     @ToString
+    @EqualsAndHashCode
     public static class StaticConfig {
         private final Set<String> targets = new TreeSet<>();
         private final Labels labels;

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -201,6 +201,7 @@ public class ECSServiceDiscoveryExporter implements InitializingBean, Runnable {
 
     @Builder
     @Getter
+    @ToString
     public static class StaticConfig {
         private final Set<String> targets = new TreeSet<>();
         private final Labels labels;

--- a/src/main/java/ai/asserts/aws/exporter/ECSTaskProvider.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSTaskProvider.java
@@ -180,7 +180,6 @@ public class ECSTaskProvider extends Collector implements InitializingBean {
                 if (taskResponse.hasTasks()) {
                     taskResponse.tasks().stream()
                             .filter(ecsTaskUtil::hasAllInfo)
-                            .filter(ecsTaskUtil::hasAllInfo)
                             .forEach(task -> resourceMapper.map(task.taskArn()).ifPresent(taskResource -> {
                                 List<StaticConfig> staticConfigs =
                                         ecsTaskUtil.buildScrapeTargets(scrapeConfig, ecsClient, cluster,

--- a/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSTaskUtil.java
@@ -8,7 +8,6 @@ import ai.asserts.aws.AWSClientProvider;
 import ai.asserts.aws.AccountProvider.AWSAccount;
 import ai.asserts.aws.RateLimiter;
 import ai.asserts.aws.TagUtil;
-import ai.asserts.aws.config.ECSTaskDefScrapeConfig;
 import ai.asserts.aws.config.ScrapeConfig;
 import ai.asserts.aws.config.ScrapeConfig.SubnetDetails;
 import ai.asserts.aws.exporter.ECSServiceDiscoveryExporter.StaticConfig;
@@ -107,15 +106,83 @@ public class ECSTaskUtil {
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public List<StaticConfig> buildScrapeTargets(ScrapeConfig scrapeConfig, EcsClient ecsClient,
                                                  Resource cluster, Optional<String> service, Task task) {
-        Map<String, String> tagLabels =
-                tagUtil.tagLabels(
-                        task.tags().stream()
-                                .map(_tag -> Tag.builder().key(_tag.key()).value(_tag.value()).build())
-                                .collect(Collectors.toList()));
+        Map<String, String> tagLabels = tagUtil.tagLabels(task.tags().stream()
+                .map(ecsTag -> Tag.builder().key(ecsTag.key()).value(ecsTag.value()).build())
+                .collect(Collectors.toList()));
+
+        LabelsBuilder labelsBuilder = getLabelsBuilder(cluster, service, task);
+
+        String ipAddress = getIPAddress(task);
+        if (ipAddress == null) {
+            log.error("Couldn't find IP address of task instance for task {}", task.taskArn());
+            return Collections.emptyList();
+        }
 
         Map<Labels, StaticConfig> targetsByLabel = new LinkedHashMap<>();
+        try {
+            String operationName = "EcsClient/describeTaskDefinition";
+            TaskDefinition taskDefinition = taskDefsByARN.get(task.taskDefinitionArn(), () ->
+                    rateLimiter.doWithRateLimit(operationName,
+                            ImmutableSortedMap.of(
+                                    SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(),
+                                    SCRAPE_REGION_LABEL, cluster.getRegion(),
+                                    SCRAPE_OPERATION_LABEL, operationName,
+                                    SCRAPE_NAMESPACE_LABEL, "AWS/ECS"
+                            ),
+                            () -> ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
+                                    .taskDefinition(task.taskDefinitionArn())
+                                    .build()).taskDefinition()));
 
-        String ipAddress;
+            if (taskDefinition.hasContainerDefinitions()) {
+                // In all cases, if a container config is specified, we use the specified port and path
+                taskDefinition.containerDefinitions().forEach(cD -> {
+                    Optional<String> pathFromLabel = getDockerLabel(cD, PROMETHEUS_METRIC_PATH_DOCKER_LABEL);
+                    Optional<String> portFromLabel = getDockerLabel(cD, PROMETHEUS_PORT_DOCKER_LABEL);
+                    labelsBuilder.availabilityZone(task.availabilityZone());
+                    String jobName = cD.name();
+                    if (pathFromLabel.isPresent() && portFromLabel.isPresent()) {
+                        log.info("Found prometheus port={}, path={} from docker labels for container {}/{}",
+                                portFromLabel.get(),
+                                pathFromLabel.get(),
+                                taskDefinition.taskDefinitionArn(),
+                                cD.name());
+                        Labels labels = labelsBuilder
+                                .job(jobName)
+                                .metricsPath(pathFromLabel.get())
+                                .container(cD.name())
+                                .build();
+
+                        labels.populateMapEntries();
+                        labels.putAll(tagLabels);
+                        Map<String, String> afterRelabeling = scrapeConfig.additionalLabels("up", labels);
+                        labels.putAll(afterRelabeling);
+                        StaticConfig staticConfig = targetsByLabel.computeIfAbsent(
+                                labels, k -> StaticConfig.builder().labels(labels).build());
+                        staticConfig.getTargets().add(format("%s:%s", ipAddress, portFromLabel.get()));
+                    } else {
+                        log.warn("Docker labels for prometheus port and path not found for container {}/{}",
+                                taskDefinition.taskDefinitionArn(),
+                                cD.name());
+                    }
+                });
+            } else {
+                log.warn("No container definitions in task definition {}", taskDefinition.taskDefinitionArn());
+            }
+        } catch (
+                Exception e) {
+            log.error("Failed to describe task definition", e);
+            return Collections.emptyList();
+        }
+
+        List<StaticConfig> targets = targetsByLabel.values().stream()
+                .filter(config -> config.getTargets().size() > 0)
+                .collect(Collectors.toList());
+        log.info("Discovered targets for task {}, {}", task.taskArn(), targets);
+        return targets;
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private LabelsBuilder getLabelsBuilder(Resource cluster, Optional<String> service, Task task) {
         Resource taskDefResource = resourceMapper.map(task.taskDefinitionArn())
                 .orElseThrow(() -> new RuntimeException("Unknown resource ARN: " + task.taskDefinitionArn()));
         Resource taskResource = resourceMapper.map(task.taskArn())
@@ -154,7 +221,11 @@ public class ECSTaskUtil {
                     .taskDefVersion(taskDefResource.getVersion())
                     .metricsPath("/metrics");
         }
+        return labelsBuilder;
+    }
 
+    private String getIPAddress(Task task) {
+        String ipAddress = null;
         Optional<KeyValuePair> ipAddressOpt = task.attachments().stream()
                 .filter(attachment -> attachment.type().equals(ENI) && attachment.hasDetails())
                 .flatMap(attachment -> attachment.details().stream())
@@ -162,110 +233,8 @@ public class ECSTaskUtil {
                 .findFirst();
         if (ipAddressOpt.isPresent()) {
             ipAddress = ipAddressOpt.get().value();
-        } else {
-            log.error("Couldn't find IP address of task instance for task   {}", task.taskArn());
-            return Collections.emptyList();
         }
-
-
-        try {
-            String operationName = "EcsClient/describeTaskDefinition";
-            TaskDefinition taskDefinition = taskDefsByARN.get(task.taskDefinitionArn(), () ->
-                    rateLimiter.doWithRateLimit(operationName,
-                            ImmutableSortedMap.of(
-                                    SCRAPE_ACCOUNT_ID_LABEL, cluster.getAccount(),
-                                    SCRAPE_REGION_LABEL, cluster.getRegion(),
-                                    SCRAPE_OPERATION_LABEL, operationName,
-                                    SCRAPE_NAMESPACE_LABEL, "AWS/ECS"
-                            ),
-                            () -> ecsClient.describeTaskDefinition(DescribeTaskDefinitionRequest.builder()
-                                    .taskDefinition(task.taskDefinitionArn())
-                                    .build()).taskDefinition()));
-
-            Map<String, Map<Integer, ECSTaskDefScrapeConfig>> configs = scrapeConfig.getECSConfigByNameAndPort();
-            if (taskDefinition.hasContainerDefinitions()) {
-                // In all cases, if a container config is specified, we use the specified port and path
-                taskDefinition.containerDefinitions().forEach(cD -> {
-                    Optional<String> pathFromLabel = getDockerLabel(cD, PROMETHEUS_METRIC_PATH_DOCKER_LABEL);
-                    Optional<String> portFromLabel = getDockerLabel(cD, PROMETHEUS_PORT_DOCKER_LABEL);
-                    labelsBuilder.availabilityZone(task.availabilityZone());
-                    String jobName = cD.name();
-                    if (configs.containsKey(cD.name())) {
-                        Map<Integer, ECSTaskDefScrapeConfig> byPort = configs.get(cD.name());
-                        ECSTaskDefScrapeConfig forAnyPort = byPort.get(-1);
-                        cD.portMappings().forEach(port -> {
-                            Labels labels;
-                            if (byPort.get(port.containerPort()) != null) {
-                                labels = labelsBuilder
-                                        .job(jobName)
-                                        .metricsPath(byPort.get(port.containerPort()).getMetricPath())
-                                        .container(cD.name())
-                                        .build();
-                            } else if (forAnyPort != null) {
-                                labels = labelsBuilder
-                                        .job(jobName)
-                                        .metricsPath(forAnyPort.getMetricPath())
-                                        .container(cD.name())
-                                        .build();
-                            } else if (scrapeConfig.isDiscoverAllECSTasksByDefault()) {
-                                labels = labelsBuilder
-                                        .job(jobName)
-                                        .metricsPath("/metrics")
-                                        .container(cD.name())
-                                        .build();
-                            } else {
-                                labels = null;
-                            }
-
-                            if (labels != null) {
-                                labels.populateMapEntries();
-                                labels.putAll(tagLabels);
-                                Map<String, String> afterRelabeling = scrapeConfig.additionalLabels("up", labels);
-                                labels.putAll(afterRelabeling);
-                                StaticConfig staticConfig = targetsByLabel.computeIfAbsent(
-                                        labels, k -> StaticConfig.builder().labels(labels).build());
-                                staticConfig.getTargets().add(format("%s:%d", ipAddress, port.hostPort()));
-                            }
-                        });
-                    } else if (pathFromLabel.isPresent() && portFromLabel.isPresent()) {
-                        Labels labels = labelsBuilder
-                                .job(jobName)
-                                .metricsPath(pathFromLabel.get())
-                                .container(cD.name())
-                                .build();
-
-                        labels.populateMapEntries();
-                        labels.putAll(tagLabels);
-                        Map<String, String> afterRelabeling = scrapeConfig.additionalLabels("up", labels);
-                        labels.putAll(afterRelabeling);
-                        StaticConfig staticConfig = targetsByLabel.computeIfAbsent(
-                                labels, k -> StaticConfig.builder().labels(labels).build());
-                        staticConfig.getTargets().add(format("%s:%s", ipAddress, portFromLabel.get()));
-                    } else if (scrapeConfig.isDiscoverAllECSTasksByDefault()) {
-                        Labels labels = labelsBuilder
-                                .job(jobName)
-                                .metricsPath("/metrics")
-                                .container(cD.name())
-                                .build();
-                        labels.populateMapEntries();
-                        labels.putAll(tagLabels);
-                        Map<String, String> afterRelabeling = scrapeConfig.additionalLabels("up", labels);
-                        labels.putAll(afterRelabeling);
-                        StaticConfig staticConfig = targetsByLabel.computeIfAbsent(
-                                labels, k -> StaticConfig.builder().labels(labels).build());
-                        cD.portMappings().forEach(port ->
-                                staticConfig.getTargets().add(format("%s:%d", ipAddress, port.hostPort())));
-                    }
-                });
-            }
-        } catch (
-                Exception e) {
-            log.error("Failed to describe task definition", e);
-            return Collections.emptyList();
-        }
-
-        return targetsByLabel.values().stream()
-                .filter(config -> config.getTargets().size() > 0).collect(Collectors.toList());
+        return ipAddress;
     }
 
     public SubnetDetails getSubnetDetails(Resource taskResource) {

--- a/src/main/java/ai/asserts/aws/exporter/Labels.java
+++ b/src/main/java/ai/asserts/aws/exporter/Labels.java
@@ -6,17 +6,19 @@ package ai.asserts.aws.exporter;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.TreeMap;
+import java.util.HashMap;
 
 import static io.micrometer.core.instrument.util.StringUtils.isNotEmpty;
 
 @Getter
 @Builder
 @ToString
-public class Labels extends TreeMap<String, String> {
+@EqualsAndHashCode(callSuper = true)
+public class Labels extends HashMap<String, String> {
     @JsonProperty("__metrics_path__")
     private String metricsPath;
     private String workload;

--- a/src/test/java/ai/asserts/aws/exporter/ECSTaskProviderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSTaskProviderTest.java
@@ -291,8 +291,8 @@ public class ECSTaskProviderTest extends EasyMockSupport {
                 .build())).andReturn(DescribeTasksResponse.builder()
                 .tasks(task1, task2)
                 .build());
-        expect(ecsTaskUtil.hasAllInfo(task1)).andReturn(true).times(2);
-        expect(ecsTaskUtil.hasAllInfo(task2)).andReturn(true).times(2);
+        expect(ecsTaskUtil.hasAllInfo(task1)).andReturn(true);
+        expect(ecsTaskUtil.hasAllInfo(task2)).andReturn(true);
         basicMetricCollector.recordLatency(eq("aws_exporter_milliseconds"), anyObject(SortedMap.class), anyLong());
 
         Resource task1Resource = Resource.builder().name("task1").build();
@@ -320,8 +320,8 @@ public class ECSTaskProviderTest extends EasyMockSupport {
                 .tasks(task3, task4)
                 .build());
 
-        expect(ecsTaskUtil.hasAllInfo(task3)).andReturn(true).times(2);
-        expect(ecsTaskUtil.hasAllInfo(task4)).andReturn(true).times(2);
+        expect(ecsTaskUtil.hasAllInfo(task3)).andReturn(true);
+        expect(ecsTaskUtil.hasAllInfo(task4)).andReturn(true);
 
         Resource task3Resource = Resource.builder().name("task3").build();
         Resource task4Resource = Resource.builder().name("task4").build();


### PR DESCRIPTION
[ch15152]

* Split list of Service ARNs into batches of 10 due to limit in `EcsClient.DescribeServices` method
* Discover scrape targets ONLY based on docker labels. Add additional diagnostics.

```
INFO  2023-03-16 19:01:16.170 pool-2-thread-7 ECSTaskUtil Found prometheus port=8010, path=/aws-exporter/actuator/prometheus from docker labels for container arn:aws:ecs:us-west-2:342994379019:task-definition/asserts-aws-integration-Dev:21/cloudwatch-exporter
WARN  2023-03-16 19:01:16.172 pool-2-thread-7 ECSTaskUtil Docker labels for prometheus port and path not found for container arn:aws:ecs:us-west-2:342994379019:task-definition/asserts-aws-integration-Dev:21/vmagent
INFO  2023-03-16 19:01:16.173 pool-2-thread-7 ECSTaskUtil Discovered targets for task arn:aws:ecs:us-west-2:342994379019:task/asserts-aws-integration-Dev/6416702d5989431d9f9c26c996530797, [ECSServiceDiscoveryExporter.StaticConfig(targets=[10.8.87.100:8010], labels=Labels(metricsPath=/aws-exporter/actuator/prometheus,...))]
INFO  2023-03-16 19:01:18.167 pool-2-thread-7 ECSTaskUtil Found prometheus port=8012, path=/workload-generator/actuator/prometheus from docker labels for container arn:aws:ecs:us-west-2:342994379019:task-definition/workload-generator:50/workload-generator
INFO  2023-03-16 19:01:18.168 pool-2-thread-7 ECSTaskUtil Found prometheus port=8014, path=/container-stats/actuator/prometheus from docker labels for container arn:aws:ecs:us-west-2:342994379019:task-definition/workload-generator:50/ecs-dockerstats-exporter
INFO  2023-03-16 19:01:18.168 pool-2-thread-7 ECSTaskUtil Discovered targets for task arn:aws:ecs:us-west-2:342994379019:task/workload-generator/69a2070f327c4dcfb864dbb34a31e9c0, [ECSServiceDiscoveryExporter.StaticConfig(targets=[10.8.4.10:8012], labels=Labels(metricsPath=/workload-generator/actuator/prometheus, ...)), ECSServiceDiscoveryExporter.StaticConfig(targets=[10.8.4.10:8014], labels=Labels(metricsPath=/container-stats/actuator/prometheus, ...))]
```
