### PR TITLE
Separate config for http and https

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,7 +1,8 @@
-ARG VM_VERSION=v1.87.3
+ARG VM_VERSION=v1.91.2
 FROM victoriametrics/vmagent:$VM_VERSION
 
 WORKDIR /
 COPY ./agent-scrape-config.yml /etc/agent-scrape-config.yml
-
-CMD ["-envflag.enable", "-promscrape.config=/etc/agent-scrape-config.yml"]
+COPY ./agent-scrape-config-https.yml /etc/agent-scrape-config-https.yml
+COPY start-vmagent.sh /
+ENTRYPOINT /start-vmagent.sh

--- a/agent-scrape-config-https.yml
+++ b/agent-scrape-config-https.yml
@@ -1,0 +1,27 @@
+scrape_configs:
+  - job_name: 'ecs-service-discovery'
+    honor_labels: true
+    file_sd_configs:
+      - files:
+          - '/opt/asserts/ecs-scrape-targets.yml'
+    relabel_configs:
+      - source_labels: [ "__name__" ]
+        regex: .+
+        target_label: tenant
+        action: replace
+        replacement: %{remoteWrite_basicAuth_username}
+  - job_name: 'ecs-service-discovery-https'
+    honor_labels: true
+    scheme: https
+    tls_config:
+      insecure_skip_verify: %{SKIP_TLS_VERIFY}
+    file_sd_configs:
+      - files:
+          - '/opt/asserts/ecs-scrape-targets-https.yml'
+    relabel_configs:
+      - source_labels: [ "__name__" ]
+        regex: .+
+        target_label: tenant
+        action: replace
+        replacement: %{remoteWrite_basicAuth_username}
+

--- a/agent-scrape-config.yml
+++ b/agent-scrape-config.yml
@@ -4,14 +4,6 @@ scrape_configs:
     file_sd_configs:
       - files:
           - '/opt/asserts/ecs-scrape-targets.yml'
-  - job_name: 'ecs-service-discovery-https'
-    honor_labels: true
-    scheme: https
-    tls_config:
-      insecure_skip_verify: %{SKIP_TLS_VERIFY}
-    file_sd_configs:
-      - files:
-          - '/opt/asserts/ecs-scrape-targets-https.yml'
     relabel_configs:
       - source_labels: [ "__name__" ]
         regex: .+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,3 +9,12 @@ services:
       - "8010:8010"
     env_file:
       - env.properties
+  aws-integration-agent:
+    build:
+      context: .
+      dockerfile: Dockerfile.agent
+    image: asserts/aws-integration-agent:v0.0.14
+    ports:
+      - "8014:8014"
+    env_file:
+      - env_agent.properties

--- a/env_agent.properties
+++ b/env_agent.properties
@@ -3,5 +3,5 @@ httpAuth_username=chief
 remoteWrite_url=https://chief.tsdb.dev.asserts.ai
 SKIP_TLS_VERIFY=true
 remoteWrite_basicAuth_password=chieftenant
-httpAuth_password=chieftenant
+httpAuth_password=
 SCRAPE_OVER_TLS=false

--- a/env_agent.properties
+++ b/env_agent.properties
@@ -2,6 +2,6 @@ remoteWrite_basicAuth_username=chief
 httpAuth_username=chief
 remoteWrite_url=https://chief.tsdb.dev.asserts.ai
 SKIP_TLS_VERIFY=true
-remoteWrite_basicAuth_password=chieftenant
+remoteWrite_basicAuth_password=
 httpAuth_password=
 SCRAPE_OVER_TLS=false

--- a/env_agent.properties
+++ b/env_agent.properties
@@ -1,0 +1,7 @@
+remoteWrite_basicAuth_username=chief
+httpAuth_username=chief
+remoteWrite_url=https://chief.tsdb.dev.asserts.ai
+SKIP_TLS_VERIFY=true
+remoteWrite_basicAuth_password=chieftenant
+httpAuth_password=chieftenant
+SCRAPE_OVER_TLS=false

--- a/start-vmagent.sh
+++ b/start-vmagent.sh
@@ -5,5 +5,5 @@ if [ "${SCRAPE_OVER_TLS}" = 'true' ]; then
   /vmagent-prod -envflag.enable -promscrape.config=/etc/agent-scrape-config-https.yml
 else
   echo "Agent will scrape remote targets over http"
-    /vmagent-prod -envflag.enable -promscrape.config=/etc/agent-scrape-config.yml
+  /vmagent-prod -envflag.enable -promscrape.config=/etc/agent-scrape-config.yml
 fi

--- a/start-vmagent.sh
+++ b/start-vmagent.sh
@@ -1,0 +1,9 @@
+#! /bin/sh
+
+if [ "${SCRAPE_OVER_TLS}" = 'true' ]; then
+  echo "Agent will scrape remote targets over https"
+  /vmagent-prod -envflag.enable -promscrape.config=/etc/agent-scrape-config-https.yml
+else
+  echo "Agent will scrape remote targets over http"
+    /vmagent-prod -envflag.enable -promscrape.config=/etc/agent-scrape-config.yml
+fi


### PR DESCRIPTION
[ch15960]

The default had the file sd config for https which resulted in spurious errors. Depending on environment property switch between http or https scrape configs

Tested in chief with `SCRAPE_OVER_TLS` set to  both `true` and `false`. Works as expected