### PR TITLE
Publish exporter jar to maven repo

### DIFF
--- a/.github/workflows/main-workflow.yaml
+++ b/.github/workflows/main-workflow.yaml
@@ -172,8 +172,8 @@ jobs:
       - name: Gradle Build
         run: ./gradlew build
 
-      - name: Publish with Gradle
-        run: ./gradlew config:publish
+      - name: Publish Config with Gradle
+        run: ./gradlew publish
 
       - name: Clear session
         run: |


### PR DESCRIPTION
[ch15961]

Tested locally

![image](https://github.com/asserts/aws-cloudwatch-exporter/assets/18289983/7d09762b-c108-4afa-9cc7-459bd0d65b65)
