### PR TITLE
Instantiate `RestTemplate` only when required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ COPY --from=builder /home/gradle/app/build/resources/main/*.xml ./
 COPY --from=builder /home/gradle/app/build/resources/main/*.properties ./
 # COPY jmx_prometheus_javaagent-0.16.1.jar ./
 # COPY httpserver_config.yml ./
-CMD ["/bin/sh", "-c", "java -Daws.exporter.deployment.mode=$DEPLOYMENT_MODE -Dhekate.enable=$HEKATE_ENABLE -Dhekate.cluster.seed.cloudstore.enable=$HEKATE_CLOUDSTORE_ENABLE -Dhekate.cluster.seed.cloudstore.provider=$HEKATE_CLOUDSTORE_PROVIDER -Dhekate.cluster.seed.cloudstore.container=$HEKATE_CLOUDSTORE_CONTAINER -Dhekate.cluster.namespace=aws-exporter -jar app-*.jar --spring.config.location=application.properties"]
+CMD ["/bin/sh", "-c", "java -Daws.exporter.deployment.mode=$DEPLOYMENT_MODE -Daws.exporter.tenant.mode=single -Dhekate.enable=$HEKATE_ENABLE -Dhekate.cluster.seed.cloudstore.enable=$HEKATE_CLOUDSTORE_ENABLE -Dhekate.cluster.seed.cloudstore.provider=$HEKATE_CLOUDSTORE_PROVIDER -Dhekate.cluster.seed.cloudstore.container=$HEKATE_CLOUDSTORE_CONTAINER -Dhekate.cluster.namespace=aws-exporter -jar app-*.jar --spring.config.location=application.properties"]
 # CMD ["/bin/sh", "-c", "java -javaagent:./jmx_prometheus_javaagent-0.16.1.jar=8095:httpserver_config.yml -jar app-*.jar --spring.config.location=application.properties"]
 
 LABEL "PROMETHEUS_EXPORTER_PORT"="8010"

--- a/src/main/java/ai/asserts/aws/AwsExporterBeanConfiguration.java
+++ b/src/main/java/ai/asserts/aws/AwsExporterBeanConfiguration.java
@@ -20,6 +20,7 @@ import org.springframework.web.client.RestTemplate;
 @SuppressWarnings("unused")
 public class AwsExporterBeanConfiguration {
     @Bean
+    @ConditionalOnProperty(name = "aws.exporter.tenant.mode", havingValue = "single", matchIfMissing = true)
     public RestTemplate restTemplate() {
         return new RestTemplate();
     }
@@ -37,6 +38,12 @@ public class AwsExporterBeanConfiguration {
     @Bean("aws-api-calls-thread-pool")
     public TaskThreadPool awsAPICallsPool(MeterRegistry meterRegistry) {
         return new TaskThreadPool("aws-api-calls-thread-pool", 5, meterRegistry);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "aws.exporter.deployment.mode",  havingValue = "single-tenant-distributed")
+    public HekateCluster hekateCluster() {
+        return new HekateCluster();
     }
 
     @Bean

--- a/src/main/java/ai/asserts/aws/cluster/HekateCluster.java
+++ b/src/main/java/ai/asserts/aws/cluster/HekateCluster.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-@Component
 public class HekateCluster implements ClusterEventListener {
     private ClusterTopology clusterTopology;
 


### PR DESCRIPTION
[ch16008]

In the enterprise server mode, the `RestTemplate` is already created leading to a conflict. While, this can be resolved by `spring.main.allow-bean-definition-overriding=true`, this is not a solution. So create this only for the ECS mode of deployment