### PR TITLE
Fix file SD parse error

### DIFF
--- a/src/main/java/ai/asserts/aws/exporter/Labels.java
+++ b/src/main/java/ai/asserts/aws/exporter/Labels.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 import java.util.HashMap;
+import java.util.TreeMap;
 
 import static ai.asserts.aws.MetricNameUtil.TENANT;
 import static io.micrometer.core.instrument.util.StringUtils.isNotEmpty;
@@ -19,7 +20,7 @@ import static io.micrometer.core.instrument.util.StringUtils.isNotEmpty;
 @Builder
 @ToString
 @EqualsAndHashCode(callSuper = true)
-public class Labels extends HashMap<String, String> {
+public class Labels extends TreeMap<String, String> {
     @JsonProperty("__metrics_path__")
     private String metricsPath;
     private String workload;

--- a/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporterTest.java
@@ -259,7 +259,7 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
 
     @Test
     public void run() throws Exception {
-        expect(environmentConfig.isSingleInstance()).andReturn(true);
+        expect(environmentConfig.isSingleTenant()).andReturn(true);
         expect(scrapeConfigProvider.getScrapeConfig(null)).andReturn(scrapeConfig);
         expect(scrapeConfig.isDiscoverECSTasks()).andReturn(true);
         expect(scrapeConfig.isDiscoverECSTasksAcrossVPCs()).andReturn(true).anyTimes();
@@ -295,7 +295,7 @@ public class ECSServiceDiscoveryExporterTest extends EasyMockSupport {
 
     @Test
     public void runTLSEnabled() {
-        expect(environmentConfig.isSingleInstance()).andReturn(true);
+        expect(environmentConfig.isSingleTenant()).andReturn(true);
         expect(scrapeConfigProvider.getScrapeConfig(null)).andReturn(scrapeConfig);
         expect(scrapeConfig.isDiscoverECSTasks()).andReturn(true);
         expect(scrapeConfig.isDiscoverECSTasksAcrossVPCs()).andReturn(true).anyTimes();

--- a/src/test/java/ai/asserts/aws/exporter/ECSTaskProviderTest.java
+++ b/src/test/java/ai/asserts/aws/exporter/ECSTaskProviderTest.java
@@ -262,10 +262,11 @@ public class ECSTaskProviderTest extends EasyMockSupport {
 
         expect(scrapeConfigProvider.getScrapeConfig(null)).andReturn(scrapeConfig);
 
-        expect(accountProvider.getAccounts()).andReturn(ImmutableSet.of(awsAccount)).times(2);
+        expect(accountProvider.getAccounts()).andReturn(ImmutableSet.of(awsAccount));
         expect(awsClientProvider.getECSClient("region", awsAccount)).andReturn(ecsClient);
         expect(ecsClusterProvider.getClusters(awsAccount, "region")).andReturn(ImmutableSet.of(cluster1));
         replayAll();
+        testClass.run();
         assertEquals(ImmutableList.of(mockStaticConfig), testClass.getScrapeTargets());
         verifyAll();
     }


### PR DESCRIPTION
[ch16021]

* Fix File SD parse error by ignoring `logConfigs` part of `StaticConfig`
* ECS Scrape target generation is supported only in single-tenant i.e. ECS mode
* Make `Labels` a `SortedMap` to see labels in order
* Discover ECS scrape targets in async