### PR TITLE
Emit ECS Meta metrics even when no prometheus instrumentation

### DIFF
--- a/config/src/main/java/ai/asserts/aws/config/ScrapeConfig.java
+++ b/config/src/main/java/ai/asserts/aws/config/ScrapeConfig.java
@@ -73,18 +73,6 @@ public class ScrapeConfig {
     private Map<String, SubnetDetails> primaryExporterByAccount = new TreeMap<>();
 
     @Builder.Default
-    private Integer listMetricsResultCacheTTLMinutes = 10;
-
-    @Builder.Default
-    private Integer listFunctionsResultCacheTTLMinutes = 5;
-
-    @Builder.Default
-    private Integer getResourcesResultCacheTTLMinutes = 5;
-
-    @Builder.Default
-    private Integer numTaskThreads = 5;
-
-    @Builder.Default
     private AuthConfig authConfig = new AuthConfig();
 
     @Builder.Default
@@ -92,9 +80,6 @@ public class ScrapeConfig {
 
     @Builder.Default
     private Integer delay = 0;
-
-    @Builder.Default
-    private Integer logScrapeDelaySeconds = 15;
 
     private TagExportConfig tagExportConfig;
 

--- a/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
+++ b/src/main/java/ai/asserts/aws/exporter/ECSServiceDiscoveryExporter.java
@@ -201,6 +201,9 @@ public class ECSServiceDiscoveryExporter implements InitializingBean, Runnable {
 
     @VisibleForTesting
     boolean shouldScrapeTargets(ScrapeConfig scrapeConfig, StaticConfig config) {
+        if( config.getTargets().isEmpty() ) {
+            return false;
+        }
         String targetVpc = config.getLabels().getVpcId();
         String targetSubnet = config.getLabels().getSubnetId();
         boolean vpcOK = scrapeConfig.isDiscoverECSTasksAcrossVPCs() ||


### PR DESCRIPTION
[ch16154]

* Build `StaticConfig` even when no prometheus targets
* Always emit meta metrics
* Build scrape target only when Prometheus instrumentation is present
* Remove unused config fields
* Reorder methods in `ECSTaskUtil` based on access
* Account level env name if present, precedes install level env name